### PR TITLE
Color Scheme Refactor

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -43,19 +43,8 @@
   /* Font families */
   --font-open-sans: "Open Sans", sans-serif;
   --font-menlo: "Menlo", monospace;
-  
-  /**
-   * Font sizes matching WordPress theme.json
-   * 
-   * These CSS variables mirror the font sizes defined in theme.json.
-   * This duplication is necessary because:
-   * 1. It allows Tailwind to access these values when generating utility classes
-   * 2. It ensures consistency between theme.json settings and CSS custom properties
-   * 3. It enables using the same font size scale in both the block editor and front end
-   * 
-   * Without these mappings, Tailwind utilities like text-xs, text-sm, etc.
-   * wouldn't match the WordPress editor's font size presets.
-   */
+
+  /* Font sizes matching theme.json */
   --wp--preset--font-size--xs: 0.75rem;
   --wp--preset--font-size--sm: 0.875rem;
   --wp--preset--font-size--base: 1rem;
@@ -69,28 +58,16 @@
   --wp--preset--font-size--7xl: 4.5rem;
   --wp--preset--font-size--8xl: 6rem;
   --wp--preset--font-size--9xl: 8rem;
-  
-  /* 
-   * IMPORTANT: Color variable mappings for Tailwind CSS
-   * 
-   * The following CSS variables are necessary for Tailwind to properly recognize
-   * and generate utility classes for WordPress theme.json colors.
-   * 
-   * Without these mappings, Tailwind utilities like text-footertext, bg-footerbg, etc. 
-   * will cause build errors. These mappings ensure compatibility between theme.json
-   * and Tailwind-generated utility classes.
-   *
-   * If you see build errors like "Cannot apply unknown utility class: text-footertext",
-   * make sure the color is defined both in theme.json AND mapped here.
-   */
-  --color-textbodygray: var(--wp--preset--color--textbodygray);
-  --color-bggray: var(--wp--preset--color--bggray);
-  --color-bordergray: var(--wp--preset--color--bordergray);
-  --color-ctablue: var(--wp--preset--color--ctablue);
-  --color-ctabuttonblue: var(--wp--preset--color--ctabuttonblue);
-  --color-ctabuttonbluehover: var(--wp--preset--color--ctabuttonbluehover);
-  --color-footerbg: var(--wp--preset--color--footerbg);
-  --color-footertext: var(--wp--preset--color--footertext);
+
+  /* Tailwind‑compatible color mappings */
+  --color-ash-gray:      var(--wp--preset--color--ash-gray);
+  --color-mist-gray:     var(--wp--preset--color--mist-gray);
+  --color-fog-gray:      var(--wp--preset--color--fog-gray);
+  --color-sky-blue:      var(--wp--preset--color--sky-blue);
+  --color-ocean-blue:    var(--wp--preset--color--ocean-blue);
+  --color-midnight-blue: var(--wp--preset--color--midnight-blue);
+  --color-graphite-black:var(--wp--preset--color--graphite-black);
+  --color-steel-gray:    var(--wp--preset--color--steel-gray);
 }
 
 /* -----------------------------------------------------------------------------
@@ -102,7 +79,7 @@
  * These styles apply to all h1-h6 elements across the site
  */
 h1 {
-  font-family: var(--wp--preset--font-family--open-sans);
+  font-family: var(--font-open-sans);
   font-weight: 800;
   font-size: var(--wp--preset--font-size--3xl);
   line-height: 1.2;
@@ -154,12 +131,13 @@ p {
   font-family: var(--font-open-sans);
   font-size: var(--wp--preset--font-size--base);
   line-height: 1.8;
-  color: var(--color-textbodygray);
+  color: var(--color-ash-gray);
 }
 
 /* Standard paragraph styling within content */
 .e-content p {
-  @apply font-open-sans text-base leading-relaxed text-gray-500;
+  font-family: var(--font-open-sans);
+  @apply text-base leading-relaxed text-ash-gray;
 }
 
 /* Common spacing for content elements */
@@ -202,17 +180,17 @@ pre > code {
   @apply list-disc leading-7 text-gray-500;
 }
 
-.wp-block-latest-posts__list .wp-block-latest-posts__post-title {
-  @apply text-footertext;
+.post .wp-block-latest-posts__list .wp-block-latest-posts__post-title {
+  @apply text-steel-gray;
 }
 
-/* List block styling */
 .wp-block-list {
   @apply list-disc list-inside;
 }
 
 .wp-block-latest-posts__post-title {
-  @apply font-open-sans text-gray-500;
+  font-family: var(--font-open-sans);
+  @apply text-ash-gray;
 }
 
 /* -----------------------------------------------------------------------------
@@ -492,17 +470,40 @@ body .gform_wrapper .gform_body {
 
 
 /* Add support for block editor color classes */
-.has-textbodygray-color {
-  color: var(--color-textbodygray);
+.has-ash-gray-color {
+  color: var(--color-ash-gray);
+}
+.has-mist-gray-color {
+  color: var(--color-mist-gray);
+}
+.has-fog-gray-color {
+  color: var(--color-fog-gray);
+}
+.has-sky-blue-color {
+  color: var(--color-sky-blue);
+}
+.has-ocean-blue-color {
+  color: var(--color-ocean-blue);
+}
+.has-midnight-blue-color {
+  color: var(--color-midnight-blue);
+}
+.has-graphite-black-color {
+  color: var(--color-graphite-black);
+}
+.has-steel-gray-color {
+  color: var(--color-steel-gray);
 }
 
-.has-black-color {
-  color: black;
-}
-
-.has-ctablue-color {
-  color: var(--color-ctablue);
-}
+/* Remove old/redundant color classes if they exist */
+.has-textbodygray-color { display: none; }
+.has-bggray-color { display: none; }
+.has-bordergray-color { display: none; }
+.has-ctablue-color { display: none; }
+.has-ctabuttonblue-color { display: none; }
+.has-ctabuttonbluehover-color { display: none; }
+.has-footerbg-color { display: none; }
+.has-footertext-color { display: none; }
 
 /* Add support for block editor font family classes */
 .has-open-sans-font-family {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -134,6 +134,14 @@ p {
   color: var(--color-ash-gray);
 }
 
+/* List item styles to match paragraph styling */
+li {
+  font-family: var(--font-open-sans);
+  font-size: var(--wp--preset--font-size--base);
+  line-height: 1.8;
+  color: var(--color-ash-gray);
+}
+
 /* Standard paragraph styling within content */
 .e-content p {
   font-family: var(--font-open-sans);
@@ -186,11 +194,6 @@ pre > code {
 
 .wp-block-list {
   @apply list-disc list-inside;
-}
-
-.wp-block-latest-posts__post-title {
-  font-family: var(--font-open-sans);
-  @apply text-ash-gray;
 }
 
 /* -----------------------------------------------------------------------------

--- a/resources/js/blocks/faq/editor.jsx
+++ b/resources/js/blocks/faq/editor.jsx
@@ -42,11 +42,11 @@ export default function Edit({ attributes, setAttributes, clientId }) {
       createBlock('core/heading', {
         level: 3,
         content: __('New Question', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }),
       createBlock('core/paragraph', {
         content: __('Enter answer here...', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }),
     ]);
     
@@ -59,32 +59,32 @@ export default function Edit({ attributes, setAttributes, clientId }) {
       ['core/heading', { 
         level: 3, 
         content: __('What\'s included in the Standard package?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('You\'ll receive a 3–5‑page site built on our customizable block theme, hosted on a shared server, fully responsive, with basic on‑page SEO and a vertical‑specific child‑theme tailored to your brand.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
     ['core/group', { className: 'faq-item' }, [
       ['core/heading', { 
         level: 3, 
         content: __('What\'s included in the Premium package?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('The Premium package includes a customized Sage based hybrid theme with bespoke design components, version control, VPS hosting on our Trellis stack for optimal performance, comprehensive SEO setup and optimization, advanced analytics integration, and a 6-month maintenance plan with regular updates and support.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
     ['core/group', { className: 'faq-item' }, [
       ['core/heading', { 
         level: 3, 
         content: __('How long does each package take to launch?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/list', { 
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }, [
         ['core/list-item', {
           content: __('<strong>Standard:</strong> ~2–3 weeks from kickoff to go‑live.', 'imagewize'),
@@ -98,44 +98,44 @@ export default function Edit({ attributes, setAttributes, clientId }) {
       ['core/heading', { 
         level: 3, 
         content: __('What is a "hybrid theme"?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('It\'s a custom WordPress theme base on Sage combining block‑based templates for easy content editing with classic PHP templates for bespoke design elements—giving you the best of both worlds.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
     ['core/group', { className: 'faq-item' }, [
       ['core/heading', { 
         level: 3, 
         content: __('What does the 6‑month maintenance plan cover?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('Monthly core, plugin, and theme updates; security monitoring; performance tweaks; and up to 4 small content or styling changes per month.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
     ['core/group', { className: 'faq-item' }, [
       ['core/heading', { 
         level: 3, 
         content: __('Do I need to supply content and images?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('Yes—client‑provided copy and high‑res images streamline the build. We can recommend stock sources or content‑writing partners if needed.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
     ['core/group', { className: 'faq-item' }, [
       ['core/heading', { 
         level: 3, 
         content: __('What is the Trellis stack?', 'imagewize'),
-        className: 'faq-question has-black-color has-text-color has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
+        className: 'faq-question text-black has-lg-font-size has-open-sans-font-family has-indicator is-collapsed',
       }],
       ['core/paragraph', { 
         content: __('Trellis is a modern, Ansible‑driven provisioning system for WordPress, providing automated security, caching, and server hardening—ideal for high‑performance VPS hosting.', 'imagewize'),
-        className: 'faq-answer has-textbodygray-color has-text-color has-open-sans-font-family collapsed',
+        className: 'faq-answer has-ash-gray-color has-text-color has-open-sans-font-family collapsed',
       }],
     ]],
   ];
@@ -170,7 +170,7 @@ export default function Edit({ attributes, setAttributes, clientId }) {
       <div {...blockProps}>
         <RichText
           tagName="h2"
-          className="faq-heading has-black-color has-text-color has-text-align-center has-3xl-font-size has-open-sans-font-family"
+          className="faq-heading text-black has-text-align-center has-3xl-font-size has-open-sans-font-family"
           value={title}
           onChange={(value) => setAttributes({ title: value })}
           placeholder={__('FAQ Section Title', 'imagewize')}

--- a/resources/js/blocks/pricing/editor.jsx
+++ b/resources/js/blocks/pricing/editor.jsx
@@ -19,7 +19,7 @@ const TEMPLATE = [
     align: 'center', 
     content: __('Choose the package that best fits your business needs', 'imagewize'), 
     className: 'pricing-main-subtitle', // Optional class
-    textColor: 'textbodygray', // Example using theme.json preset
+    textColor: 'ash-gray', // Updated from textbodygray
     fontSize: 'lg' // Example using theme.json preset
   }],
   ['core/group', { 
@@ -40,7 +40,7 @@ const TEMPLATE = [
         ['core/heading', { level: 3, content: __('Standard', 'imagewize') }],
         ['core/paragraph', { 
           content: __('Perfect for small websites that need a professional presence.', 'imagewize'),
-          textColor: 'textbodygray',
+          textColor: 'ash-gray', // Updated from textbodygray
           fontSize: 'lg'
         }],
         ['core/heading', { 
@@ -48,10 +48,10 @@ const TEMPLATE = [
           content: `<strong>${__('€799', 'imagewize')}</strong> <span style="font-weight:normal;font-size:1rem;color:#98999a">${__('starting price', 'imagewize')}</span>` 
         }],
         // Features - represented as paragraphs
-        ['core/paragraph', { content: __('Shared hosting with trusted hosting partners', 'imagewize'), textColor: 'textbodygray', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('Responsive, mobile friendly design', 'imagewize'), textColor: 'textbodygray', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('Basic SEO setup', 'imagewize'), textColor: 'textbodygray', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('Turnkey Theme tailored to your business', 'imagewize'), textColor: 'textbodygray' }], // Last item, no border class
+        ['core/paragraph', { content: __('Shared hosting with trusted hosting partners', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
+        ['core/paragraph', { content: __('Responsive, mobile friendly design', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
+        ['core/paragraph', { content: __('Basic SEO setup', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
+        ['core/paragraph', { content: __('Turnkey Theme tailored to your business', 'imagewize'), textColor: 'ash-gray' }], // Updated from textbodygray, Last item, no border class
         // Button
         ['core/buttons', { style: { spacing: { margin: { top: '2rem' } } }, layout: { type: 'flex', justifyContent: 'left' } }, [
           ['core/button', { 
@@ -67,13 +67,14 @@ const TEMPLATE = [
       ['core/column', { 
         backgroundColor: 'black', // Example using theme.json preset
         style: { 
-          border: { width: '2px', color: '#017cb6', radius: '0.5rem' },
+          border: { width: '2px', color: 'var(--wp--preset--color--sky-blue)', radius: '0.5rem' }, // Updated from hardcoded color to use sky-blue variable
           spacing: { padding: { top: '2rem', right: '2rem', bottom: '2rem', left: '2rem' } }
         } 
       }, [
         ['core/heading', { 
           level: 3, 
-          content: `${__('Premium', 'imagewize')} <span class="has-ctablue-color has-text-color has-background has-xs-font-size" style="border-radius:1rem;background-color:#e8f7fd;padding:0.5rem 1rem;font-size:0.75rem;margin-left:0.5rem"><strong>${__('MOST POPULAR', 'imagewize')}</strong></span>`,
+          // Updated span class from has-ctablue-color to has-sky-blue-color
+          content: `${__('Premium', 'imagewize')} <span class="has-sky-blue-color has-text-color has-background has-xs-font-size" style="border-radius:1rem;background-color:#e8f7fd;padding:0.5rem 1rem;font-size:0.75rem;margin-left:0.5rem"><strong>${__('MOST POPULAR', 'imagewize')}</strong></span>`,
           textColor: 'white'
         }],
         ['core/paragraph', { 

--- a/resources/js/blocks/pricing/editor.jsx
+++ b/resources/js/blocks/pricing/editor.jsx
@@ -31,7 +31,7 @@ const TEMPLATE = [
     ['core/columns', { style: { spacing: { blockGap: { top: '2rem', left: '2rem' } } } }, [
       // Standard Column
       ['core/column', { 
-        backgroundColor: 'base', // Example using theme.json preset
+        backgroundColor: 'white', // Changed from 'base'
         style: { 
           border: { width: '1px', color: '#cbcbcb', radius: '0.5rem' },
           spacing: { padding: { top: '2rem', right: '2rem', bottom: '2rem', left: '2rem' } }
@@ -48,17 +48,60 @@ const TEMPLATE = [
           content: `<strong>${__('€799', 'imagewize')}</strong> <span style="font-weight:normal;font-size:1rem;color:#98999a">${__('starting price', 'imagewize')}</span>` 
         }],
         // Features - represented as paragraphs
-        ['core/paragraph', { content: __('Shared hosting with trusted hosting partners', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
-        ['core/paragraph', { content: __('Responsive, mobile friendly design', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
-        ['core/paragraph', { content: __('Basic SEO setup', 'imagewize'), textColor: 'ash-gray', className: 'pricing-feature-item' }], // Updated from textbodygray
-        ['core/paragraph', { content: __('Turnkey Theme tailored to your business', 'imagewize'), textColor: 'ash-gray' }], // Updated from textbodygray, Last item, no border class
+        ['core/paragraph', { 
+          content: __('Shared hosting with trusted hosting partners', 'imagewize'), 
+          textColor: 'ash-gray', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(0,0,0,0.1)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('Responsive, mobile friendly design', 'imagewize'), 
+          textColor: 'ash-gray', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(0,0,0,0.1)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('Basic SEO setup', 'imagewize'), 
+          textColor: 'ash-gray', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(0,0,0,0.1)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('Turnkey Theme tailored to your business', 'imagewize'), 
+          textColor: 'ash-gray' 
+          // last item: no border/margin/padding
+        }],
         // Button
         ['core/buttons', { style: { spacing: { margin: { top: '2rem' } } }, layout: { type: 'flex', justifyContent: 'left' } }, [
           ['core/button', { 
             text: __('Get Started', 'imagewize'), 
             url: '#', // Default URL, user can change
-            backgroundColor: 'black', 
-            textColor: 'base', 
+            backgroundColor: 'black', // Changed from 'base'
+            textColor: 'white', 
             style: { border: { radius: '0.5rem' } } 
           }]
         ]]
@@ -88,16 +131,59 @@ const TEMPLATE = [
           textColor: 'white'
         }],
         // Features - represented as paragraphs
-        ['core/paragraph', { content: __('Premium VPS hosting (Trellis stack with Micro Caching, A+ SSL, WP CLI)', 'imagewize'), textColor: 'white', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('Custom hybrid theme (block + classic elements)', 'imagewize'), textColor: 'white', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('Advanced SEO optimization', 'imagewize'), textColor: 'white', className: 'pricing-feature-item' }],
-        ['core/paragraph', { content: __('6-month maintenance plan', 'imagewize'), textColor: 'white' }], // Last item, no border class
+        ['core/paragraph', { 
+          content: __('Premium VPS hosting (Trellis stack with Micro Caching, A+ SSL, WP CLI)', 'imagewize'), 
+          textColor: 'white', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(255,255,255,0.15)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('Custom hybrid theme (block + classic elements)', 'imagewize'), 
+          textColor: 'white', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(255,255,255,0.15)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('Advanced SEO optimization', 'imagewize'), 
+          textColor: 'white', 
+          className: 'pricing-feature-item',
+          style: {
+            spacing: { padding: { bottom: '2rem' }, margin: { bottom: '2rem' } },
+            border: { 
+              top: { width: '0px', style: 'none' },
+              right: { width: '0px', style: 'none' },
+              bottom: { width: '2px', style: 'solid', color: 'rgba(255,255,255,0.15)' },
+              left: { width: '0px', style: 'none' }
+            }
+          }
+        }],
+        ['core/paragraph', { 
+          content: __('6-month maintenance plan', 'imagewize'), 
+          textColor: 'white' 
+          // last item: no border/margin/padding
+        }],
         // Button
         ['core/buttons', { style: { spacing: { margin: { top: '2rem' } } }, layout: { type: 'flex', justifyContent: 'left' } }, [
           ['core/button', { 
             text: __('Get Started', 'imagewize'), 
             url: '#', // Default URL, user can change
-            backgroundColor: 'base', 
+            backgroundColor: 'white', 
             textColor: 'black', 
             style: { border: { radius: '0.5rem' } } 
           }]

--- a/resources/js/blocks/pricing/style.css
+++ b/resources/js/blocks/pricing/style.css
@@ -28,19 +28,6 @@
   box-shadow: 0 10px 25px #00000014;
 }
 
-/* Add bottom border to feature items */
-.wp-block-imagewize-pricing .wp-block-column.has-base-background-color .pricing-feature-item {
-  border-bottom: 2px solid rgba(0, 0, 0, 0.1); /* Lighter, transparent border for light background */
-  padding-bottom: 2rem; /* Spacing below text */
-  margin-bottom: 2rem; /* Spacing below border */
-}
-
-.wp-block-imagewize-pricing .wp-block-column.has-black-background-color .pricing-feature-item {
-  border-bottom: 2px solid rgba(255, 255, 255, 0.15); /* Lighter, transparent border for dark background */
-  padding-bottom: 2rem; /* Spacing below text */
-  margin-bottom: 2rem; /* Spacing below border */
-}
-
 /* Responsive adjustments if necessary for the container */
 /* @media screen and (min-width: 768px) {
   .wp-block-imagewize-pricing {

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -32,7 +32,7 @@
             text-white md:after:absolute md:after:left-1/2 md:after:bottom-0 md:after:w-10 md:after:h-[3px] 
             md:after:-ml-[21px] md:after:bg-neutral-600 md:after:content-[""] md:after:block 
             md:after:transition-all md:after:duration-300 md:after:ease-in-out' : '' }} 
-            flex md:block py-2 px-4 no-underline font-open-sans text-textbodygray hover:text-white" 
+            flex md:block py-2 px-4 no-underline font-open-sans text-ash-gray hover:text-white" 
             role="none">
                 <a href="{{ str_contains($item->url, '#') && !Str::startsWith($item->url, home_url()) ? esc_url(home_url('/')) . ltrim($item->url, '/') : $item->url }}" 
                    role="menuitem" 
@@ -54,7 +54,7 @@
                 @if ($item->children)
                   <!-- Child menu items start -->
                   <ul class="hidden md:group-hover:block md:absolute md:top-full md:left-0 md:min-w-[200px] 
-                  md:bg-neutral-900 md:shadow-lg md:z-50 text-sm text-textbodygray"
+                  md:bg-neutral-900 md:shadow-lg md:z-50 text-sm text-ash-gray"
                       role="menu" 
                       aria-label="{{ $item->label }} submenu">
                     @foreach ($item->children as $child)
@@ -77,11 +77,11 @@
       <div class="flex items-center" id="nav-content">
          <!-- facebook icon -->
         <a class="inline-block no-underline " href="https://www.facebook.com/imagewize/" aria-label="Facebook Account">
-        <x-css-facebook class="fill-current text-white hover:text-textbodygray w-6 h-6 ml-3" />
+        <x-css-facebook class="fill-current text-white hover:text-ash-gray w-6 h-6 ml-3" />
         </a>
         <!-- github icons -->
         <a class="pl-3 inline-block no-underline" href="https://github.com/imagewize/" aria-label="Github">
-          <x-fab-github class="text-white hover:text-textbodygray" />
+          <x-fab-github class="text-white hover:text-ash-gray" />
         </a>
       </div>
     </div> <!-- navigation container end -->

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,7 +3,8 @@
 @section('content')
   @include('partials.page-header')
 
-  <div class="container mx-auto max-w-6xl my-16 font-open-sans text-textbodygray text-base leading-loose">
+  {{-- Updated text-textbodygray to text-ash-gray --}}
+  <div class="container mx-auto max-w-6xl my-16 font-open-sans text-ash-gray text-base leading-loose">
     @if (! have_posts())
       <x-alert type="warning">
         {!! __('Sorry, no results were found.', 'sage') !!}

--- a/resources/views/partials/content-front-page.blade.php
+++ b/resources/views/partials/content-front-page.blade.php
@@ -6,11 +6,11 @@
         @php(the_row())
 
         @if(get_row_layout() == 'about_block')
-            <section id="about" class="py-24 bg-bggray">
+            <section id="about" class="py-24 bg-mist-gray">
                 <div class="container mx-auto max-w-5xl px-4">
                     <div class="flex flex-col md:flex-row gap-8">
                         <div class="md:w-1/4 w-full">
-                            <div id="about-profile" class="rounded-full overflow-hidden w-24 h-24 border-8 border-bordergray mx-auto">
+                            <div id="about-profile" class="rounded-full overflow-hidden w-24 h-24 border-8 border-fog-gray mx-auto">
                                 @php($image = get_sub_field('about_profile_picture'))
                                 @if(!empty($image))
                                     <img src="{{ $image['url'] }}" alt="{{ $image['alt'] }}" class="w-full h-full object-cover">
@@ -19,8 +19,8 @@
                         </div>
                         <div class="md:w-3/4 w-full">
                             <h2 id="about-header" class="text-3xl font-open-sans font-semi-bold mb-6">{{ get_sub_field('about_title') }}</h2>
-                            <p class="text-xl leading-relaxed font-light mb-6 text-textbodygray font-open-sans">{{ get_sub_field('about_lead') }}</p>
-                            <div class="prose text-textbodygray text-base leading-loose font-open-sans">{!! get_sub_field('about_text') !!}</div>
+                            <p class="text-xl leading-relaxed font-light mb-6 text-ash-gray font-open-sans">{{ get_sub_field('about_lead') }}</p>
+                            <div class="prose text-ash-gray text-base leading-loose font-open-sans">{!! get_sub_field('about_text') !!}</div>
                         </div>
                     </div>
                 </div>
@@ -31,7 +31,7 @@
                 <div class="container mx-auto max-w-4xl px-4">
                     <div class="mb-12">
                         <h2 class="text-3xl font-bold text-center font-open-sans">{{ get_sub_field('services_title') }}</h2>
-                        <p class="mx-auto  max-w-2xl text-xl leading-relaxed my-8 text-center text-textbodygray font-open-sans font-light container">
+                        <p class="mx-auto  max-w-2xl text-xl leading-relaxed my-8 text-center text-ash-gray font-open-sans font-light container">
                           {{ get_sub_field('services_introduction_text_block') }}
                         </p>
                     </div>
@@ -43,18 +43,18 @@
                             @php(the_row())
                             <div class="service-block bg-white p-6 rounded-lg group hover:cursor-pointer">
                                 <div class="grid grid-cols-[auto_1fr] gap-4 items-start">
-                                    <span class="service-icon inline-flex p-2 text-3xl bg-blue-600 rounded-lg 
+                                    <span class="service-icon inline-flex p-2 text-3xl bg-sky-blue rounded-lg 
                                     group-hover:bg-red-500 transition-colors duration-200">  
                                        <x-dynamic-component :component="get_sub_field('text_box_icon')" class="text-white w-8 h-8" />
                                     </span>
-                                    <h3 class="service-title text-lg text-blue-600 group-hover:text-gray-700 font-semibold relative inline-block">
+                                    <h3 class="service-title text-lg text-sky-blue group-hover:text-gray-700 font-semibold relative inline-block">
                                         <span class="relative inline-block">
                                             {{ get_sub_field('text_box_title') }}
-                                            <span class="absolute -bottom-2 left-0 w-1/4 h-[3px] bg-gray-300 
-                                            group-hover:w-1/2 group-hover:bg-gray-700 transition-all duration-300"></span>
+                                            <span class="absolute -bottom-2 left-0 w-1/4 h-[3px] bg-fog-gray 
+                                            group-hover:w-1/2 group-hover:bg-steel-gray transition-all duration-300"></span>
                                         </span>
                                     </h3>
-                                    <div class="service-body prose text-textbodygray font-open-sans leading-loose col-start-2">
+                                    <div class="service-body prose text-ash-gray font-open-sans leading-loose col-start-2">
                                         {!! get_sub_field('text_box') !!}
                                     </div>
                                 </div>
@@ -103,12 +103,12 @@
             </section>
 
         @elseif(get_row_layout() == 'cta_banner')
-            <section id="CTA" class="py-16 bg-ctablue text-white">
+            <section id="CTA" class="py-16 bg-sky-blue text-white">
                 <div class="container mx-auto max-w-2xl px-4 text-center">
                     <h2 class="text-3xl font-open-sans font-bold my-6">{{ get_sub_field('cta_title') }}</h2>
                     <p class="text-lg font-open-sans mb-8">{{ get_sub_field('cta_text') }}</p>
                     <a href="{{ get_sub_field('cta_button_url') }}" class="inline-flex items-center justify-center h-16 w-full max-w-80 px-8 py-3 
-                    bg-ctabuttonblue hover:bg-ctabuttonbluehover text-white rounded-lg font-semibold">
+                    bg-ocean-blue hover:bg-midnight-blue text-white rounded-lg font-semibold">
                         {{ get_sub_field('cta_button_text') }}
                     </a>
                 </div>

--- a/resources/views/partials/content.blade.php
+++ b/resources/views/partials/content.blade.php
@@ -2,7 +2,7 @@
   <article @php(post_class('lg:grid lg:grid-cols-12 lg:gap-4 mb-12 mx-5 md:mx-none'))>
     
     <div class="col-span-2 flex justify-center items-start pt-2">
-      <div class="hidden lg:flex rounded-full overflow-hidden w-24 h-24 border-8 border-bordergray">
+      <div class="hidden lg:flex rounded-full overflow-hidden w-24 h-24 border-8 border-fog-gray">
         {!! get_avatar(get_the_author_meta('ID'), 96, '', '', ['class' => 'w-full h-full object-cover']) !!}
       </div>
     </div>
@@ -18,13 +18,13 @@
       </header>
     </div>
 
-    <div class="col-span-4 entry-summary font-open-sans text-base leading-loose text-textbodygray">
+    <div class="col-span-4 entry-summary font-open-sans text-base leading-loose text-ash-gray">
       @php(the_excerpt())
     </div>
 
     <div class="col-span-2 hidden lg:flex items-start justify-center pt-2">
-      <a href="{{ get_permalink() }}" class="inline-block px-4 py-2 text-gray-800 font-open-sans font-bold text-xl 
-      uppercase tracking-wide border-b-4 border-gray-400">
+      <a href="{{ get_permalink() }}" class="inline-block px-4 py-2 text-black font-open-sans font-bold text-xl 
+      uppercase tracking-wide border-b-4 border-fog-gray">
         Read More
       </a>
     </div>

--- a/resources/views/sections/footer.blade.php
+++ b/resources/views/sections/footer.blade.php
@@ -1,9 +1,9 @@
-<footer class="content-info py-20 px-10 bg-footerbg text-footertext font-open-sans">
+<footer class="content-info py-20 px-10 bg-graphite-black text-steel-gray font-open-sans">
   @php(dynamic_sidebar('sidebar-footer'))
 </footer>
 
 <div id="go-top" class="hidden fixed bottom-8 right-8 z-50">
-  <a class="back-to-top flex items-center justify-center w-12 h-12 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-all duration-300 shadow-lg" href="#top" title="Back to Top">
+  <a class="back-to-top flex items-center justify-center w-12 h-12 bg-sky-blue hover:bg-ocean-blue text-white rounded-lg transition-all duration-300 shadow-lg" href="#top" title="Back to Top">
     <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
       <path d="M18 15l-6-6-6 6"/>
     </svg>

--- a/resources/views/woocommerce/content-single-product.php
+++ b/resources/views/woocommerce/content-single-product.php
@@ -87,7 +87,7 @@ if ($categories) {
 }
 ?>
         
-        <div class="summary entry-summary font-open-sans text-bggray">
+        <div class="summary entry-summary font-open-sans text-mist-gray">
           <?php do_action('woocommerce_single_product_summary'); ?>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.5.1
+Version:            1.6.0
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve

--- a/theme.json
+++ b/theme.json
@@ -56,126 +56,16 @@
       "defaultPalette": false,
       "duotone": [],
       "palette": [
-        {
-          "color": "inherit",
-          "name": "Inherit",
-          "slug": "inherit"
-        },
-        {
-          "color": "currentcolor",
-          "name": "Current",
-          "slug": "current"
-        },
-        {
-          "color": "transparent",
-          "name": "Transparent",
-          "slug": "transparent"
-        },
-        {
-          "color": "#000",
-          "name": "Black",
-          "slug": "black"
-        },
-        {
-          "color": "#fff",
-          "name": "White",
-          "slug": "white"
-        },
-        {
-          "color": "#98999a",
-          "name": "TextBodyGray",
-          "slug": "textbodygray"
-        },
-        {
-          "color": "#ebeced",
-          "name": "BgGray",
-          "slug": "bggray"
-        },
-        {
-          "color": "#cbcbcb",
-          "name": "BorderGray",
-          "slug": "bordergray"
-        },
-        {
-          "color": "#017cb6",
-          "name": "CtaBlue",
-          "slug": "ctablue"
-        },
-        {
-          "color": "#026492",
-          "name": "CtaButtonBlue",
-          "slug": "ctabuttonblue"
-        },
-        {
-          "color": "#02567e",
-          "name": "CtaButtonBlueHover",
-          "slug": "ctabuttonbluehover"
-        },
-        {
-          "color": "#171b23",
-          "name": "FooterBg",
-          "slug": "footerbg"
-        },
-        {
-          "color": "#465166",
-          "name": "FooterText",
-          "slug": "footertext"
-        },
-        {
-          "name": "Brand",
-          "slug": "primary",
-          "color": "#017cb6"
-        },
-        {
-          "name": "Brand Accent",
-          "slug": "primary-accent",
-          "color": "#e8f7fd"
-        },
-        {
-          "name": "Brand Alt",
-          "slug": "primary-alt",
-          "color": "#026492"
-        },
-        {
-          "name": "Brand Alt Accent",
-          "slug": "primary-alt-accent",
-          "color": "#02567e"
-        },
-        {
-          "name": "Contrast",
-          "slug": "main",
-          "color": "#171b23"
-        },
-        {
-          "name": "Contrast Accent",
-          "slug": "main-accent",
-          "color": "#465166"
-        },
-        {
-          "name": "Base",
-          "slug": "base",
-          "color": "#fff"
-        },
-        {
-          "name": "Base Accent",
-          "slug": "secondary",
-          "color": "#98999a"
-        },
-        {
-          "name": "Tint",
-          "slug": "tertiary",
-          "color": "#ebeced"
-        },
-        {
-          "name": "Border Base",
-          "slug": "border-light",
-          "color": "#cbcbcb"
-        },
-        {
-          "name": "Border Contrast",
-          "slug": "border-dark",
-          "color": "#465166"
-        }
+        { "color": "#98999a", "name": "Ash Gray", "slug": "ash-gray" },
+        { "color": "#ebeced", "name": "Mist Gray", "slug": "mist-gray" },
+        { "color": "#cbcbcb", "name": "Fog Gray", "slug": "fog-gray" },
+
+        { "color": "#017cb6", "name": "Sky Blue", "slug": "sky-blue" },
+        { "color": "#026492", "name": "Ocean Blue", "slug": "ocean-blue" },
+        { "color": "#02567e", "name": "Midnight Blue", "slug": "midnight-blue" },
+
+        { "color": "#171b23", "name": "Graphite Black", "slug": "graphite-black" },
+        { "color": "#465166", "name": "Steel Gray", "slug": "steel-gray" }
       ]
     },
     "custom": {


### PR DESCRIPTION
This pull request focuses on updating the CSS and JavaScript files to improve consistency, readability, and maintainability by aligning color and font mappings with updated design tokens. It also refines the structure and styling of FAQ and pricing blocks in the codebase.

### CSS Updates

* **Font and Color Variables**: Simplified comments and updated CSS variables for font sizes and colors to align with the new design tokens. For example, `--color-textbodygray` was replaced with `--color-ash-gray`. [[1]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L47-R47) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L73-R70)
* **Element Styling**: Updated styles for `h1`, `p`, `li`, and `.wp-block-latest-posts__post-title` to use the new color and font variables, ensuring consistency across elements. [[1]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L105-R82) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L157-R148) [[3]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L205-L217)
* **Deprecated Classes**: Removed old color classes (e.g., `.has-textbodygray-color`) and added replacements with updated class names (e.g., `.has-ash-gray-color`).

### JavaScript Updates

* **FAQ Block**: Updated `className` properties in the FAQ block editor to use the new color classes, such as replacing `has-textbodygray-color` with `has-ash-gray-color`. [[1]](diffhunk://#diff-c509110f41f65317f10bcf8fa586e739b63e1f2aa70473150377355ef4461d7eL45-R49) [[2]](diffhunk://#diff-c509110f41f65317f10bcf8fa586e739b63e1f2aa70473150377355ef4461d7eL62-R87) [[3]](diffhunk://#diff-c509110f41f65317f10bcf8fa586e739b63e1f2aa70473150377355ef4461d7eL101-R138) [[4]](diffhunk://#diff-c509110f41f65317f10bcf8fa586e739b63e1f2aa70473150377355ef4461d7eL173-R173)
* **Pricing Block**: Adjusted template configurations to use updated color variables and added inline styles for enhanced design, such as replacing `textbodygray` with `ash-gray` and using `sky-blue` for borders and highlights. [[1]](diffhunk://#diff-5b9c84e02042c89b1ed43618570f5c133f79834602eeb193932892535d078e5fL22-R22) [[2]](diffhunk://#diff-5b9c84e02042c89b1ed43618570f5c133f79834602eeb193932892535d078e5fL34-R34) [[3]](diffhunk://#diff-5b9c84e02042c89b1ed43618570f5c133f79834602eeb193932892535d078e5fL43-R104) [[4]](diffhunk://#diff-5b9c84e02042c89b1ed43618570f5c133f79834602eeb193932892535d078e5fL70-R120)