### PR TITLE
Navigation Bar LG Breakpoint

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -5,7 +5,7 @@
       <!-- wrapper for logo and menu -->
       <div class="flex items-center">
         <!-- Toggle icon starts -->
-        <label for="menu-toggle" class="cursor-pointer md:hidden block" aria-label="Toggle menu">
+        <label for="menu-toggle" class="cursor-pointer lg:hidden block" aria-label="Toggle menu">
           <svg class="fill-current text-white" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
               <title>menu</title>
               <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"></path>
@@ -14,25 +14,25 @@
         <input class="peer hidden" type="checkbox" id="menu-toggle" aria-hidden="true" />
         <!-- Toggle icon ends -->
         <!-- Logo starts -->
-        <div id="logo" class="md:mb-4" role="banner">
+        <div id="logo" class="lg:mb-4" role="banner">
             <a class="brand flex items-center tracking-wide no-underline hover:no-underline font-bold text-white text-xl 
-            uppercase ml-5 md:ml-0 mr-5" href="{{ home_url('/') }}">
+            uppercase ml-5 lg:ml-0 mr-5" href="{{ home_url('/') }}">
             {!! $siteName !!}
             </a>
         </div>
         <!-- Logo ends -->
         <!-- Menu starts -->
-        <div id="menu" class="hidden peer-checked:block md:flex md:items-center 
-        w-full md:w-auto absolute top-12 left-0 md:static bg-neutral-900 md:bg-none" role="menubar">
-          <ul class="md:flex items-center text-sm py-4 md:pt-0">
+        <div id="menu" class="hidden peer-checked:block lg:flex lg:items-center 
+        w-full lg:w-auto absolute top-12 left-0 lg:static bg-neutral-900 lg:bg-none" role="menubar">
+          <ul class="lg:flex items-center text-sm py-4 lg:pt-0">
             @foreach ($menu->all() as $item)
             <li class="group my-menu-item relative 
             {{ $item->classes ?? '' }} 
             {{ $item->active && !str_contains($item->url, '#') ? 'active 
-            text-white md:after:absolute md:after:left-1/2 md:after:bottom-0 md:after:w-10 md:after:h-[3px] 
-            md:after:-ml-[21px] md:after:bg-neutral-600 md:after:content-[""] md:after:block 
-            md:after:transition-all md:after:duration-300 md:after:ease-in-out' : '' }} 
-            flex md:block py-2 px-4 no-underline font-open-sans text-ash-gray hover:text-white" 
+            text-white lg:after:absolute lg:after:left-1/2 lg:after:bottom-0 lg:after:w-10 lg:after:h-[3px] 
+            lg:after:-ml-[21px] lg:after:bg-neutral-600 lg:after:content-[""] lg:after:block 
+            lg:after:transition-all lg:after:duration-300 lg:after:ease-in-out' : '' }} 
+            flex lg:block py-2 px-4 no-underline font-open-sans text-ash-gray hover:text-white" 
             role="none">
                 <a href="{{ str_contains($item->url, '#') && !Str::startsWith($item->url, home_url()) ? esc_url(home_url('/')) . ltrim($item->url, '/') : $item->url }}" 
                    role="menuitem" 
@@ -53,8 +53,8 @@
                 </a>
                 @if ($item->children)
                   <!-- Child menu items start -->
-                  <ul class="hidden md:group-hover:block md:absolute md:top-full md:left-0 md:min-w-[200px] 
-                  md:bg-neutral-900 md:shadow-lg md:z-50 text-sm text-ash-gray"
+                  <ul class="hidden lg:group-hover:block lg:absolute lg:top-full lg:left-0 lg:min-w-[200px] 
+                  lg:bg-neutral-900 lg:shadow-lg lg:z-50 text-sm text-ash-gray"
                       role="menu" 
                       aria-label="{{ $item->label }} submenu">
                     @foreach ($item->children as $child)

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.7.0
+Version:            1.7.1
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request updates the responsive breakpoints in the navigation component to replace `md` (medium) with `lg` (large) for various layout and styling classes. The changes aim to adjust the navigation behavior and appearance for larger screen sizes.

### Responsive breakpoint updates:

* Changed the `menu-toggle` label's breakpoint from `md:hidden` to `lg:hidden` to hide the toggle icon on large screens instead of medium screens. (`resources/views/components/navigation.blade.php`, [resources/views/components/navigation.blade.phpL8-R8](diffhunk://#diff-3abc6fc9847ae05f2f1af6029dec19eedc20be90586061e80f7a150ee47df779L8-R8))
* Updated the logo's margin classes from `md:mb-4` and `md:ml-0` to `lg:mb-4` and `lg:ml-0` to apply these styles at the large breakpoint. (`resources/views/components/navigation.blade.php`, [resources/views/components/navigation.blade.phpL17-R35](diffhunk://#diff-3abc6fc9847ae05f2f1af6029dec19eedc20be90586061e80f7a150ee47df779L17-R35))
* Replaced `md:flex` and related classes with `lg:flex` for the main menu to make it visible and styled as a flex container starting at the large breakpoint. (`resources/views/components/navigation.blade.php`, [resources/views/components/navigation.blade.phpL17-R35](diffhunk://#diff-3abc6fc9847ae05f2f1af6029dec19eedc20be90586061e80f7a150ee47df779L17-R35))
* Adjusted the hover styles for menu items, changing `md:after` pseudo-element classes to `lg:after` to apply hover effects at the large breakpoint. (`resources/views/components/navigation.blade.php`, [resources/views/components/navigation.blade.phpL17-R35](diffhunk://#diff-3abc6fc9847ae05f2f1af6029dec19eedc20be90586061e80f7a150ee47df779L17-R35))
* Updated the child menu's hover and positioning styles from `md:group-hover` and `md:absolute` to `lg:group-hover` and `lg:absolute` for large screens. (`resources/views/components/navigation.blade.php`, [resources/views/components/navigation.blade.phpL56-R57](diffhunk://#diff-3abc6fc9847ae05f2f1af6029dec19eedc20be90586061e80f7a150ee47df779L56-R57))