### PR TITLE
Hero Mobile Image Resize

### DIFF
--- a/resources/css/blocks/hero-block-editor.css
+++ b/resources/css/blocks/hero-block-editor.css
@@ -101,8 +101,8 @@
 
 .edit-post-visual-editor .wp-block-acf-hero .editor-mobile-image {
   display: block !important;
-  width: 150px !important;
-  height: 150px !important;
+  width: 125px !important;
+  height: 125px !important;
   margin: 0 auto !important;
 }
 

--- a/resources/css/blocks/hero-block-style.css
+++ b/resources/css/blocks/hero-block-style.css
@@ -46,8 +46,8 @@
 /* Show mobile image on mobile */
 .wp-block-acf-hero .editor-mobile-image {
   display: block;
-  width: 150px; /* Fixed width for mobile image */
-  height: 150px; /* Fixed height for mobile image */
+  width: 125px; /* Fixed width for mobile image */
+  height: 125px; /* Fixed height for mobile image */
   margin: 0 auto; /* Center on mobile */
 }
 
@@ -79,8 +79,8 @@
   
   /* Maintain the fixed size for mobile image on tablet */
   .wp-block-acf-hero .editor-mobile-image {
-    width: 150px;
-    height: 150px;
+    width: 125px;
+    height: 125px;
     margin: 0; /* Left-aligned on tablet */
   }
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.8.0
+Version:            1.8.1
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request includes updates to the `hero-block` styles to adjust mobile and tablet image dimensions, as well as a version bump for the WordPress theme. The most important changes are outlined below:

### Style Adjustments for `hero-block`:

* [`resources/css/blocks/hero-block-editor.css`](diffhunk://#diff-3a2ea01c503666dbc5d6d0938f83702c942831df2a315a8e5f4b6c0ad0dd9b2fL104-R105): Reduced the width and height of `.editor-mobile-image` from 150px to 125px to improve layout consistency.
* [`resources/css/blocks/hero-block-style.css`](diffhunk://#diff-c9b74daf67d8c65159dee526ec43b46a3c66e01197be5ff173325698c3618223L49-R50): Updated the mobile and tablet dimensions for `.editor-mobile-image` to 125px width and height, ensuring consistent sizing across devices. [[1]](diffhunk://#diff-c9b74daf67d8c65159dee526ec43b46a3c66e01197be5ff173325698c3618223L49-R50) [[2]](diffhunk://#diff-c9b74daf67d8c65159dee526ec43b46a3c66e01197be5ff173325698c3618223L82-R83)

### Theme Version Update:

* [`style.css`](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL5-R5): Incremented the theme version from `1.8.0` to `1.8.1` to reflect the changes made in this release.