### PR TITLE
Content Link Colors

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -149,6 +149,55 @@ li {
   @apply text-base leading-relaxed text-ash-gray;
 }
 
+/* Link styling for content areas only - distinctive color without underlines */
+/* Target specific content areas where blog post and page content appears */
+.e-content a,
+.entry-summary a,
+.entry-content a,
+.post-content a,
+.page-content a,
+.prose a,
+.page-container a,
+article .e-content a,
+article .entry-summary a,
+.wp-block-group a:not(.wp-element-button),
+.wp-block-post-content a:not(.wp-element-button) {
+  color: var(--color-sky-blue) !important;
+  text-decoration: none !important;
+  transition: color 0.2s ease;
+}
+
+.e-content a:hover,
+.entry-summary a:hover,
+.entry-content a:hover,
+.post-content a:hover,
+.page-content a:hover,
+.prose a:hover,
+.page-container a:hover,
+article .e-content a:hover,
+article .entry-summary a:hover,
+.wp-block-group a:not(.wp-element-button):hover,
+.wp-block-post-content a:not(.wp-element-button):hover {
+  color: var(--color-ocean-blue) !important;
+}
+
+/* Specifically exclude navigation and footer areas from link styling */
+nav a,
+.navigation a,
+header a,
+footer a,
+.menu a,
+.wp-block-navigation a {
+  color: inherit !important;
+  text-decoration: inherit !important;
+}
+
+/* Specific logo styling to maintain white color */
+#logo a.brand {
+  color: #ffffff !important;
+  text-decoration: none !important;
+}
+
 /* Common spacing for content elements */
 .e-content input,
 .e-content textarea,

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.9.2
+Version:            1.9.3
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve

--- a/theme.json
+++ b/theme.json
@@ -4,16 +4,6 @@
   "version": 3,
   "styles": {
     "elements": {
-      "link": {
-        ":hover": {
-          "typography": {
-            "textDecoration": "none"
-          }
-        },
-        "typography": {
-          "textDecoration": "none"
-        }
-      },
       "heading": {
         "typography": {
           "fontFamily": "var(--wp--preset--font-family--open-sans)"


### PR DESCRIPTION
This pull request focuses on updating link styling across the theme to improve consistency and readability, while excluding specific areas like navigation and footer from these styles. It also includes a version update for the theme. Below are the key changes grouped by their themes:

### Link Styling Updates:
* Added new link styling rules in `resources/css/app.css` to target content areas (e.g., `.e-content`, `.entry-content`, `.post-content`) with a distinctive color (`--color-sky-blue`) and hover effect (`--color-ocean-blue`). These styles ensure links are visually prominent in content areas.
* Excluded navigation, footer, and logo links from the new link styles to maintain their original appearance. For example, `nav a`, `.menu a`, and `#logo a.brand` retain their inherited or specific styles.

### Theme Version Update:
* Updated the theme version in `style.css` from `1.9.2` to `1.9.3` to reflect the latest changes.

### Removal of Redundant Link Styles:
* Removed redundant link styling from `theme.json`, which previously enforced no text decoration for links and hover states. These rules are now handled in `app.css` for better centralization and maintainability.