### PR TITLE
Readme related articles block update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Nynaeve includes several custom blocks that extend the WordPress editor function
 
 - **Modern Pricing Table** (`imagewize/pricing`): A modern comparison of website packages with pricing and feature details in a two-column layout.
 - **FAQ Section** (`imagewize/faq`): A collapsible FAQ section with questions and answers.
+- **Related Articles** (`imagewize/related-articles`): A dynamic block that displays related blog posts with the following features:
+  - Three relationship modes: by tags, by categories, or most recent posts
+  - Configurable number of articles (1-20)
+  - Displays article title, excerpt, and publication date
+  - Editable block title with RichText support
+  - Support for wide and full width alignments
+  - Live preview in the editor with loading states
+  - Responsive grid layout for article display
 - **Hero Block** (`acf/hero`): An ACF Composer-based responsive hero section with the following features:
   - Fully responsive design with different layouts for mobile, tablet, and desktop
   - Split-pane design with text and image columns that rearrange based on screen size

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.10
+Version:            1.10.1
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request introduces a new custom block to the WordPress editor and includes a minor version update to the theme. The most important changes are as follows:

### New WordPress Editor Block:
* Added a **Related Articles** block (`imagewize/related-articles`) to the `README.md`. This block dynamically displays related blog posts with features like relationship modes (by tags, categories, or most recent posts), configurable article count, responsive grid layout, and live preview in the editor.

### Theme Version Update:
* Updated the theme version from `1.10` to `1.10.1` in `style.css`.