### PR TITLE
Fix anchor navigation for submenu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this theme will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.2] - 2025-09-28
+
+### Fixed
+- Fixed anchor link navigation for child menu items - submenu items with anchor links (like #reviews under Clients) now properly navigate to homepage anchors from sub-pages
+
 ## [1.13.1] - 2025-07-29
 
 ### Fixed

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -60,7 +60,12 @@
                     @foreach ($item->children as $child)
                       <li class="my-child-item {{ $child->classes ?? '' }} {{ $child->active ? 'active text-white' : '' }} block no-underline 
                        py-2 px-4 hover:text-white" role="none">
-                        <a href="{{ $child->url }}" role="menuitem" class="no-underline">
+                        <a href="{{ str_contains($child->url, '#') && !Str::startsWith($child->url, home_url()) ? esc_url(home_url('/')) . ltrim($child->url, '/') : $child->url }}"
+                           role="menuitem"
+                           @if (str_contains($child->url, '#'))
+                             data-home-anchor="true"
+                           @endif
+                           class="no-underline">
                           {{ $child->label }}
                         </a>
                       </li>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.13.1
+Version:            1.13.2
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request addresses a navigation issue with anchor links in submenu items and updates the theme version. The most important changes are:

Navigation fixes:

* Updated anchor link handling for child menu items in `navigation.blade.php` so that submenu items with anchor links (e.g., `#reviews` under Clients) now correctly navigate to homepage anchors from sub-pages. Added logic to rewrite URLs and a `data-home-anchor` attribute for these links.

Versioning and documentation:

* Bumped the theme version to `1.13.2` in `style.css`.
* Added a changelog entry for version `1.13.2` in `CHANGELOG.md`, documenting the anchor link navigation fix.