### PR TITLE
Full Width Breakout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this theme will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.3] - 2025-09-29
+
+### Fixed
+- Fixed alignfull elements not breaking out of Tailwind container constraints - full-width blocks now properly span the entire viewport width
+
 ## [1.13.2] - 2025-09-28
 
 ### Fixed

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -565,3 +565,18 @@ body .gform_wrapper .gform_body {
 .has-montserrat-font-family {
   font-family: var(--font-montserrat);
 }
+
+/* -----------------------------------------------------------------------------
+ * 11. WordPress Layout Fixes
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Fix for alignfull elements breaking out of container constraints
+ * Ensures full-width blocks span the entire viewport regardless of Tailwind container utilities
+ */
+.alignfull {
+  max-width: none !important;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.13.2
+Version:            1.13.3
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request addresses a layout issue with WordPress full-width (`alignfull`) blocks not properly breaking out of Tailwind CSS container constraints. The fix ensures that full-width elements now span the entire viewport as intended. The theme version is also bumped to 1.13.3, and the changelog is updated to reflect this fix.

Layout Fixes:

* Added CSS rules for the `.alignfull` class in `app.css` to ensure full-width blocks span the entire viewport and are no longer constrained by Tailwind containers.

Release Management:

* Updated the version number in `style.css` to 1.13.3.
* Added a new entry to `CHANGELOG.md` for version 1.13.3, documenting the alignfull layout fix.