### PR TITLE
Horizontal Scrollbar vw Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this theme will be documented in this file.
 
 ## [Unreleased]
 
+## [1.13.5] - 2025-09-30
+
+### Fixed
+- Fixed horizontal scrollbar issue caused by alignfull blocks and Slick carousel using 100vw which includes scrollbar width
+- Improved alignfull CSS to use percentage-based margins (-50%) instead of viewport-based (-50vw) to avoid scrollbar width issues
+- Added max-width: 100vw constraint to alignfull blocks for proper self-containment
+- Added overflow-x: hidden to html/body specifically for Slick carousel infinite scroll track
+
 ## [1.13.4] - 2025-09-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,46 @@ All blocks are automatically registered via `app/Providers/ThemeServiceProvider.
 - Use Laravel debugging features via Acorn
 - Browser dev tools for frontend debugging
 
+### Important CSS Considerations
+
+#### Viewport Width (vw) and Scrollbar Issues
+When using `100vw` or `calc()` with `vw` units for full-width elements, be aware that:
+
+- **`100vw` includes the scrollbar width** (~15px on Windows/Linux)
+- This causes horizontal scrollbars when the body has a vertical scrollbar
+- **Avoid using `-50vw` margins** for breaking out of containers
+
+**Recommended Approaches:**
+
+1. **For `.alignfull` blocks** - Use percentage-based margins:
+   ```css
+   .alignfull {
+     width: 100%;
+     max-width: 100vw;  /* Constrains to viewport */
+     position: relative;
+     left: 50%;
+     margin-left: -50%;  /* Use % not vw */
+     margin-right: -50%;
+   }
+   ```
+
+2. **For carousels/sliders** - Use `overflow-x: hidden` on parent:
+   ```css
+   html, body {
+     overflow-x: hidden;  /* Clips carousel overflow */
+   }
+   ```
+
+3. **Alternative solutions:**
+   - Use CSS Grid or Flexbox with `minmax()` for full-width layouts
+   - Use JavaScript to calculate actual viewport width excluding scrollbar
+   - Use container queries for responsive full-width elements
+
+**References:**
+- This is a known CSS limitation across browsers
+- Mac users often don't see the issue (overlay scrollbars)
+- Always test on Windows/Linux with visible scrollbars
+
 ## Custom Components
 
 The theme includes several pre-built components:

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -75,7 +75,17 @@
  * 3. Typography & General Content Styling
  * -------------------------------------------------------------------------- */
 
-/* 
+/* Prevent horizontal scrollbar from Slick carousel
+ * The carousel's .slick-track extends beyond viewport for infinite scrolling
+ * Note: .alignfull blocks are now self-constrained with max-width: 100vw
+ */
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/*
  * Heading styles - moved from theme.json for easier override
  * These styles apply to all h1-h6 elements across the site
  */
@@ -565,12 +575,16 @@ body .gform_wrapper .gform_body {
 /**
  * Fix for alignfull elements breaking out of container constraints
  * Ensures full-width blocks span the entire viewport regardless of Tailwind container utilities
+ * Uses max-width to prevent overflow instead of vw units
  */
 .alignfull {
-  max-width: none !important;
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  width: 100%;
+  max-width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50%;
+  margin-right: -50%;
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.13.4
+Version:            1.13.5
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request addresses a persistent horizontal scrollbar issue caused by the use of viewport width (`vw`) units in full-width elements (notably `.alignfull` blocks and the Slick carousel). The changes implement a more robust CSS strategy to prevent unwanted overflow and improve layout compatibility across browsers and operating systems. The documentation has also been updated to explain these CSS considerations and solutions.

**CSS fixes for overflow and scrollbar issues:**

* Updated `.alignfull` CSS to use percentage-based margins (`-50%`) and `max-width: 100vw` instead of `-50vw` margins and `width: 100vw`, preventing horizontal scrollbars and ensuring full-width alignment without overflow. (`resources/css/app.css`, [resources/css/app.cssR578-R587](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998R578-R587))
* Added `overflow-x: hidden` and `max-width: 100%` to `html, body` to contain overflow from Slick carousel and other elements, further preventing horizontal scrollbars. (`resources/css/app.css`, [resources/css/app.cssR78-R87](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998R78-R87))

**Documentation and versioning updates:**

* Added a new section in `CLAUDE.md` explaining the pitfalls of `vw` units, the scrollbar issue, and recommended CSS strategies for full-width layouts, with code examples and references.
* Updated `CHANGELOG.md` to document the scrollbar fix, improved alignfull CSS, and carousel containment.
* Bumped theme version to `1.13.5` in `style.css`.