### PR TITLE
Tailwind Container Removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this theme will be documented in this file.
 
 ## [Unreleased]
 
+## [1.14.0] - 2025-09-30
+
+### Changed
+- **BREAKING**: Removed Tailwind container wrapper from page templates to adopt WordPress native layout system
+- Page templates now let WordPress blocks self-manage layout via `is-layout-constrained` classes
+- Removed custom `.alignfull` CSS - WordPress core now handles full-width blocks natively
+- Updated `page.blade.php` to remove `container mx-auto px-4 max-w-contentSize` wrapper
+- Updated `content-page.blade.php` to remove `.page-container` wrapper
+- Removed `.page-container` references from link styling CSS
+
+### Fixed
+- Fixed `.alignfull` blocks not spanning full viewport width on pages with WordPress constrained layouts
+- Eliminated horizontal scrollbar issues by adopting WordPress's native block layout system
+- Full-width blocks now work correctly without custom viewport-width CSS hacks
+
+### Technical Details
+- WordPress blocks with `is-layout-constrained` automatically center at `contentSize` (880px from theme.json)
+- `.alignfull` blocks automatically span full viewport via WordPress core CSS
+- No more double-wrapping (Tailwind container + WordPress layout)
+- Aligns with modern block themes like Ollie that don't wrap post content in theme containers
+
 ## [1.13.5] - 2025-09-30
 
 ### Fixed

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -167,7 +167,6 @@ li {
 .post-content a,
 .page-content a,
 .prose a,
-.page-container a,
 article .e-content a,
 article .entry-summary a,
 .wp-block-group a:not(.wp-element-button),
@@ -183,7 +182,6 @@ article .entry-summary a,
 .post-content a:hover,
 .page-content a:hover,
 .prose a:hover,
-.page-container a:hover,
 article .e-content a:hover,
 article .entry-summary a:hover,
 .wp-block-group a:not(.wp-element-button):hover,
@@ -573,19 +571,10 @@ body .gform_wrapper .gform_body {
  * -------------------------------------------------------------------------- */
 
 /**
- * Fix for alignfull elements breaking out of container constraints
- * Ensures full-width blocks span the entire viewport regardless of Tailwind container utilities
- * Uses max-width to prevent overflow instead of vw units
+ * WordPress core handles .alignfull natively - no custom CSS needed
+ * The native implementation works correctly with theme.json layout settings
+ * and doesn't cause horizontal scrollbar issues
  */
-.alignfull {
-  width: 100%;
-  max-width: 100vw;
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50%;
-  margin-right: -50%;
-}
 
 /**
  * WordPress-native spacing for alignfull blocks

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -3,8 +3,7 @@
 @section('content')
   @while(have_posts()) @php(the_post())
     @include('partials.page-header')
-    <div class="container mx-auto px-4 max-w-contentSize">
-      @includeFirst(['partials.content-page', 'partials.content'])
-    </div>
+    {{-- No container wrapper - WordPress blocks handle their own layout via is-layout-constrained --}}
+    @includeFirst(['partials.content-page', 'partials.content'])
   @endwhile
 @endsection

--- a/resources/views/partials/content-page.blade.php
+++ b/resources/views/partials/content-page.blade.php
@@ -1,9 +1,8 @@
-<div class="page-container mb-16">
-  @php(the_content())
+{{-- WordPress blocks self-manage layout via is-layout-constrained --}}
+@php(the_content())
 
-  @if ($pagination())
-    <nav class="page-nav" aria-label="Page">
-      {!! $pagination !!}
-    </nav>
-  @endif
-</div>
+@if ($pagination())
+  <nav class="page-nav" aria-label="Page">
+    {!! $pagination !!}
+  </nav>
+@endif

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:         Nynaeve
 Theme URI:          https://imagewize.com
 Description:        A custom WordPress theme for Imagewize based on Sage 11
-Version:            1.13.5
+Version:            1.14.0
 Author:             Jasper Frumau
 Author URI:         https://magewize.com
 Text Domain:        nynaeve


### PR DESCRIPTION
This pull request introduces a breaking change to the theme's layout system by removing the Tailwind container wrappers from page templates and fully adopting WordPress's native block layout system. The update simplifies template structure, eliminates custom CSS for full-width blocks, and resolves horizontal scrollbar issues. The documentation and CSS have been updated to reflect these changes, aligning the theme with modern WordPress block theme conventions.

**Theme Layout Overhaul**

* Removed all Tailwind container wrappers (e.g., `container mx-auto px-4 max-w-contentSize`, `.page-container`) from page templates (`page.blade.php` and `content-page.blade.php`), letting WordPress blocks manage their own layout using `is-layout-constrained` classes. This is a breaking change that aligns with modern block themes and prevents double-wrapping of content. [[1]](diffhunk://#diff-b45c2d84238f15539f4742ba9940bf5f553d16cff8cad6f408d0db1e5e5b2353L6-L8) [[2]](diffhunk://#diff-93c25997864f46040e8b183564b569140e25b7c4697cc124cd064e25eff2b5baL1-L9)
* Removed custom `.alignfull` CSS and all references to `.page-container` in link styling, relying instead on WordPress core CSS for full-width block support. [[1]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L170) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L186) [[3]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L576-L588)

**Documentation Updates**

* Updated `CLAUDE.md` with new layout conventions: do not wrap `the_content()` in container classes, and let WordPress blocks self-manage layout. Provided code examples and clarified differences between legacy and modern approaches. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R193-R215) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L232-R285)
* Added detailed changelog in `CHANGELOG.md` for version 1.14.0, documenting the breaking changes, fixes for full-width blocks, and technical details about the new layout system.

**Version Bump**

* Updated theme version to 1.14.0 in `style.css` to reflect these significant changes.