### PR TITLE
Service Hero Styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.11.0] - 2026-04-21
+
+### Added
+
+**Service Hero Block — Colour Scheme Styles:**
+- Added four selectable colour schemes to the `imagewize/service-hero` block via WordPress block styles
+- **Midnight Blue** (default): existing dark `#0e0e0e` background with dual blue radial gradient overlay
+- **Forest Green**: deep `#071a0e` background with green radial gradient; green-tinted eyebrow pill, italic title accent (`#86efac`), and green CTA button (`#16a34a`)
+- **Violet**: deep `#0d0714` background with violet radial gradient; violet-tinted eyebrow pill, italic title accent (`#c4b5fd`), and violet CTA button (`#7c3aed`)
+- **Slate Teal**: deep navy `#05111a` background with teal radial gradient; teal-tinted eyebrow pill, italic title accent (`#5eead4`), and teal CTA button (`#0d9488`)
+- All colour schemes apply coordinated hover states on CTA buttons with matching coloured box shadows
+- Colour scheme selector is available directly in the block toolbar / styles panel in the editor
+
+### Technical
+
+**Service Hero Block Style Registration:**
+- Added `registerBlockStyle` import from `@wordpress/blocks` in `editor.jsx`
+- Block styles registered inline in editor context for `imagewize/service-hero`: `midnight`, `forest`, `violet`, `slate`
+- Refactored base CSS to share selectors between the unstyled default and the explicit `is-style-midnight` class for forward compatibility",
+
 ## [2.10.0] - 2026-04-21
 
 ### Added

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 2.9.0
+Stable tag: 2.11.0
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,20 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.11.0 - 04/21/26 =
+* ADDED: Service Hero block - Four colour scheme styles: Midnight Blue (default), Forest Green, Violet, and Slate Teal, selectable via the block styles panel.
+* ADDED: Service Hero Forest Green style - Deep green background with radial gradient, green eyebrow/title accent, and green CTA button.
+* ADDED: Service Hero Violet style - Deep purple background with violet radial gradient, violet eyebrow/title accent, and violet CTA button.
+* ADDED: Service Hero Slate Teal style - Dark navy background with teal radial gradient, teal eyebrow/title accent, and teal CTA button.
+* TECHNICAL: Service Hero - Registered block styles via registerBlockStyle() in editor.jsx; refactored base CSS to support is-style-* class variants."
+
+
+= 2.10.0 - 04/21/26 =
+* ADDED: Category description support in page header - Archive pages for categories, tags, and custom taxonomies now display the term description below the page title when one is set.
+* ADDED: Post view composer - `app/View/Composers/Post.php` exposes a `description()` method that returns `category_description()` for category/tag/taxonomy archives and an empty string elsewhere.
+* ADDED: page-header.blade.php - Conditionally renders the term description in a styled div with primary-accent text color, Open Sans font, and centered layout.
+
 
 = 2.9.0 - 04/08/26 =
 * CHANGED: Block category system - Updated from single `imagewize` category to semantic subcategories prefixed with `nynaeve/` (nynaeve/hero, nynaeve/features, nynaeve/cta, nynaeve/testimonials, nynaeve/pricing, nynaeve/content, nynaeve/media, nynaeve/portfolio); category slugs now match the theme name prefix, consistent with Elayne theme conventions

--- a/resources/js/blocks/service-hero/editor.jsx
+++ b/resources/js/blocks/service-hero/editor.jsx
@@ -2,12 +2,18 @@
  * WordPress dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { registerBlockStyle } from '@wordpress/blocks';
 
 /**
  * Icon URLs resolved via imagewize/theme-icon block binding.
  * window.imagewizeIcons is injected by setup.php enqueue_block_editor_assets.
  */
 const icons = window.imagewizeIcons ?? {};
+
+registerBlockStyle('imagewize/service-hero', { name: 'midnight', label: 'Midnight Blue', isDefault: true });
+registerBlockStyle('imagewize/service-hero', { name: 'forest',   label: 'Forest Green' });
+registerBlockStyle('imagewize/service-hero', { name: 'violet',   label: 'Violet' });
+registerBlockStyle('imagewize/service-hero', { name: 'slate',    label: 'Slate Teal' });
 
 /**
  * Hero InnerBlocks template.

--- a/resources/js/blocks/service-hero/style.css
+++ b/resources/js/blocks/service-hero/style.css
@@ -5,14 +5,19 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 .wp-block-imagewize-service-hero {
-  background: #0e0e0e;
   padding: 80px 0 72px;
   position: relative;
   overflow: hidden;
 }
 
-/* Dual radial blue gradient overlay */
-.wp-block-imagewize-service-hero::before {
+/* ── Colour scheme: Midnight Blue (default) ───────────────────────────────── */
+.wp-block-imagewize-service-hero,
+.wp-block-imagewize-service-hero.is-style-midnight {
+  background: #0e0e0e;
+}
+
+.wp-block-imagewize-service-hero::before,
+.wp-block-imagewize-service-hero.is-style-midnight::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -21,6 +26,121 @@
     radial-gradient(ellipse 300px 300px at 10% 80%, rgba(37, 99, 235, 0.08) 0%, transparent 60%);
   pointer-events: none;
 }
+
+/* ── Colour scheme: Forest Green ─────────────────────────────────────────── */
+.wp-block-imagewize-service-hero.is-style-forest {
+  background: #071a0e;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 600px 400px at 80% 50%, rgba(22, 163, 74, 0.20) 0%, transparent 70%),
+    radial-gradient(ellipse 300px 300px at 10% 80%, rgba(22, 163, 74, 0.09) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest .service-hero__eyebrow {
+  background: rgba(22, 163, 74, 0.15);
+  border-color: rgba(22, 163, 74, 0.35);
+  color: #86efac !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest .service-hero__eyebrow p {
+  color: #86efac !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest .service-hero__title em {
+  color: #86efac;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link {
+  background: #16a34a;
+}
+
+.wp-block-imagewize-service-hero.is-style-forest .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+  background: #15803d;
+  box-shadow: 0 4px 20px rgba(22, 163, 74, 0.35);
+}
+
+/* ── Colour scheme: Violet ───────────────────────────────────────────────── */
+.wp-block-imagewize-service-hero.is-style-violet {
+  background: #0d0714;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 600px 400px at 80% 50%, rgba(124, 58, 237, 0.20) 0%, transparent 70%),
+    radial-gradient(ellipse 300px 300px at 10% 80%, rgba(124, 58, 237, 0.09) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet .service-hero__eyebrow {
+  background: rgba(124, 58, 237, 0.15);
+  border-color: rgba(124, 58, 237, 0.35);
+  color: #c4b5fd !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet .service-hero__eyebrow p {
+  color: #c4b5fd !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet .service-hero__title em {
+  color: #c4b5fd;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link {
+  background: #7c3aed;
+}
+
+.wp-block-imagewize-service-hero.is-style-violet .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+  background: #6d28d9;
+  box-shadow: 0 4px 20px rgba(124, 58, 237, 0.35);
+}
+
+/* ── Colour scheme: Slate Teal ───────────────────────────────────────────── */
+.wp-block-imagewize-service-hero.is-style-slate {
+  background: #05111a;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 600px 400px at 80% 50%, rgba(20, 184, 166, 0.18) 0%, transparent 70%),
+    radial-gradient(ellipse 300px 300px at 10% 80%, rgba(20, 184, 166, 0.08) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate .service-hero__eyebrow {
+  background: rgba(20, 184, 166, 0.15);
+  border-color: rgba(20, 184, 166, 0.35);
+  color: #5eead4 !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate .service-hero__eyebrow p {
+  color: #5eead4 !important;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate .service-hero__title em {
+  color: #5eead4;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link {
+  background: #0d9488;
+}
+
+.wp-block-imagewize-service-hero.is-style-slate .service-hero__ctas .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+  background: #0f766e;
+  box-shadow: 0 4px 20px rgba(20, 184, 166, 0.35);
+}
+
 
 /* Content wrapper — constrained to wideSize (64rem), left-aligned */
 .service-hero__content {
@@ -87,7 +207,7 @@
   font-size: clamp(2rem, 5vw, 3.2rem);
   color: #ffffff;
   line-height: 1.15;
-  max-width: 680px;
+  max-width: 780px;
   margin-bottom: 24px !important;
 }
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.10.0
+Version: 2.11.0
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
This release adds four colour scheme variants to the `imagewize/service-hero` block via WordPress block styles, giving content editors a one-click way to change the hero's visual theme directly from the block toolbar. Each scheme — Midnight Blue (default), Forest Green, Violet, and Slate Teal — applies a distinct dark background, a matching dual-ellipse radial gradient overlay, and coordinated accent colours to the eyebrow pill, italic title highlight, and primary CTA button, while the outline button remains neutral across all schemes. The implementation registers the four styles via `registerBlockStyle` in `editor.jsx` and drives all visual changes through `is-style-*` CSS selectors in `style.css`, keeping the InnerBlocks template untouched and maintaining full user control over content. The theme version has been bumped to 2.11.0 in `style.css`, `CHANGELOG.md`, and `readme.txt`.

**Colour Scheme Feature (`service-hero` block):**
- Added four named block styles — `midnight` (default), `forest`, `slate`, and `violet` — registered via `registerBlockStyle` in `editor.jsx`, making them selectable in the block toolbar's Styles panel without any custom inspector controls.
- Each scheme targets `.wp-block-imagewize-service-hero.is-style-*` and overrides the block background, `::before` radial-gradient overlay, eyebrow pill colours, `em` italic title accent, and primary button background/hover state, all coordinated to the scheme's accent hue.
- The default Midnight Blue gradient uses `rgba(37,99,235,…)` blue tones; Forest Green uses `rgba(22,163,74,…)`; Violet uses `rgba(124,58,237,…)`; Slate Teal uses `rgba(20,184,166,…)`.

**Architecture and Standards:**
- Colour overrides are applied purely through CSS `is-style-*` class selectors, consistent with the theme's philosophy of avoiding hardcoded style classes in block templates and preserving user control.
- The outline/ghost CTA button intentionally inherits no scheme-specific overrides, keeping its neutral appearance (`rgba(255,255,255,0.25)` border) across all four variants.

**Release and Documentation:**
- Theme version bumped to 2.11.0 across `style.css`, `CHANGELOG.md`, and `readme.txt` to reflect the new block style feature.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/service-hero-styles/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/service-hero-styles/readme.txt) (Modified)
- [`resources/js/blocks/service-hero/editor.jsx`](https://github.com/imagewize/nynaeve/blob/service-hero-styles/resources/js/blocks/service-hero/editor.jsx) (Modified)
- [`resources/js/blocks/service-hero/style.css`](https://github.com/imagewize/nynaeve/blob/service-hero-styles/resources/js/blocks/service-hero/style.css) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/service-hero-styles/style.css) (Modified)