### PR TITLE
fix: upgrade tj-actions/changed-files to v46.0.1 (CVE-2025-30066)

### DIFF
--- a/.github/workflows/block-compliance.yml
+++ b/.github/workflows/block-compliance.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get Changed Block Files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v46.0.1
         with:
           files: resources/js/blocks/**
 


### PR DESCRIPTION
## Summary

- Upgrades `tj-actions/changed-files` from `v44` to `v46.0.1` in `.github/workflows/block-compliance.yml`
- Resolves Dependabot alert [#22](https://github.com/imagewize/nynaeve/security/dependabot/22)
- Versions ≤ 45.0.7 were affected by a supply chain attack (CVE-2025-30066) that exfiltrated CI secrets via workflow logs

## Test plan

- [ ] Verify the Block Compliance workflow runs successfully on this PR
- [ ] Confirm Dependabot alert #22 is dismissed after merge