### PR TITLE
Single Post Meta Mobile Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.11.1] - 2026-04-23
+
+### Fixed
+
+**Single Post Entry-Meta Mobile Wrapping:**
+- Restructured entry-meta into two `flex-nowrap` groups: dates (Pub./Upd.) and author+category, so each group wraps as a unit on narrow viewports
+- Author name and category tag now stay on the same line on mobile instead of breaking onto separate lines
+- Outer `flex-wrap` container allows the two groups to stack cleanly when the viewport is too narrow to fit both
+
 ## [2.11.0] - 2026-04-21
 
 ### Added

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 2.11.0
+Stable tag: 2.11.1
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,10 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.11.1 - 04/23/26 =
+* FIXED: Single post entry-meta mobile layout - restructured into two flex-nowrap groups (dates and author+category) so each wraps as a unit; author name and category tag now stay on the same line on mobile.
+
 
 = 2.11.0 - 04/21/26 =
 * ADDED: Service Hero block - Four colour scheme styles: Midnight Blue (default), Forest Green, Violet, and Slate Teal, selectable via the block styles panel.

--- a/resources/views/partials/entry-meta.blade.php
+++ b/resources/views/partials/entry-meta.blade.php
@@ -20,20 +20,18 @@
         </span>
       @endif
     @endif
+  </span>
 
+  <span class="flex items-center gap-x-2 flex-nowrap">
     <span class="text-gray-400">•</span>
-
     <span>{{ __('By', 'sage') }}</span>
     <a href="{{ get_author_posts_url(get_the_author_meta('ID')) }}" class="p-author h-card hover:text-indigo-600 transition-colors">
       {{ get_the_author() }}
     </a>
 
-  </span>
-
-  @if(is_single())
-    @php($categories = get_the_category())
-    @if($categories)
-      <span class="flex items-center gap-x-1">
+    @if(is_single())
+      @php($categories = get_the_category())
+      @if($categories)
         <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M12 2H2v10l10 10L22 12 12 2z"/>
           <circle cx="7" cy="7" r="1" fill="currentColor" stroke="none"/>
@@ -41,7 +39,7 @@
         <a href="{{ esc_url(get_category_link($categories[0]->term_id)) }}" class="hover:text-indigo-600 transition-colors">
           {{ esc_html($categories[0]->name) }}
         </a>
-      </span>
+      @endif
     @endif
-  @endif
+  </span>
 </div>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.11.0
+Version: 2.11.1
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
Version 2.11.1 of the Nynaeve theme resolves a mobile layout regression in the single post entry-meta partial, where author name and category tags were breaking onto separate lines on narrow viewports due to unconstrained flex wrapping. The fix restructures `entry-meta.blade.php` into two semantically grouped `flex-nowrap` spans — one for date information (published and updated) and one for author and category — while the outer container retains `flex-wrap` to allow the two groups to stack vertically as a unit when the viewport is too narrow to accommodate both. This approach preserves the existing responsive stacking behavior while preventing mid-group line breaks that produced visually fragmented metadata on mobile. Four files were modified across the template, version metadata, and changelog (22 insertions, 11 deletions).

**Template Restructuring:**
- `resources/views/partials/entry-meta.blade.php` was reorganized from a flat flex row into two discrete `flex-nowrap` child spans, grouping `dt-published`/`u-updated` dates together and the author link with category tag together, so each group wraps atomically on narrow screens.
- The bullet separator (`·`) between published and updated dates is now scoped inside the dates group, and the dot separator (`•`) before the author group is positioned at the start of the second span, preserving visual rhythm on all viewport widths.

**Version and Release Metadata:**
- `style.css` and `readme.txt` bumped to version 2.11.1 to reflect the patch release.
- `CHANGELOG.md` updated with a `[2.11.1] - 2026-04-23` entry documenting the mobile wrapping fix and the structural approach used.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/single-post-meta-mobile-update/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/single-post-meta-mobile-update/readme.txt) (Modified)
- [`resources/views/partials/entry-meta.blade.php`](https://github.com/imagewize/nynaeve/blob/single-post-meta-mobile-update/resources/views/partials/entry-meta.blade.php) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/single-post-meta-mobile-update/style.css) (Modified)