### PR TITLE
Contact Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.12.0] - 2026-04-24
+
+### Added
+
+**Contact Section Block (`nynaeve/contact-section`):**
+- New full-width dark contact section block combining an info column and a Contact Form 7 form card
+- Intro area with eyebrow label, heading with italic accent, and subtext paragraph
+- Left column displays contact details (email, response time, location) using theme SVG icons in styled icon boxes
+- Animated "Available for new projects" badge with pulsing green dot (CSS keyframe animation)
+- Right column renders a CF7 shortcode inside a frosted-glass card (`backdrop-filter: blur`)
+- CSS Grid two-column layout for name + email fields side-by-side in the form card
+- Responsive breakpoint at 860 px: single-column stacked layout with form card above info column
+- Secondary breakpoint at 520 px: reduced section and card padding for small phones
+- Decorative radial-gradient glow pseudo-elements (top-right and bottom-left corners)
+- Block editor preview styles (`editor.css`) keep the dark background, two-column grid, and card visible in the WordPress block editor
+- Block supports `wide` and `full` alignment, margin/padding spacing controls, and HTML anchors
+- Default alignment set to `full` with zero top/bottom margin to allow seamless full-width placement
+
+**Mail Icon:**
+- Added `icon-mail.svg` (28×28, brand blue `#017cb6` stroke) to the theme icon library
+- Registered `icon-mail.svg` in block editor assets alongside the existing contact-section icons
+
+**Contact Form 7 Global Styles (section 16 in `app.css`):**
+- Comprehensive CF7 stylesheet covering labels, text/email/tel/number/url/date/search inputs, textarea, select, checkboxes, radio buttons, submit button, spinner, validation tips, and response banners
+- Submit button styled with primary brand color, hover lift effect (`translateY(-1px)`) and drop shadow
+- Invalid field highlight (red border + red focus ring) and inline error tip in red
+- Success response banner (green border/background) and validation/spam-error banner (orange border/background)
+- Dark-background variant via `.wpcf7-on-dark` utility class: semi-transparent inputs, white text/labels, dimmed placeholders, and primary-color focus ring; applies `2rem` internal padding when wrapping a dark group column",
+
 ## [2.11.1] - 2026-04-23
 
 ### Fixed

--- a/app/setup.php
+++ b/app/setup.php
@@ -468,6 +468,8 @@ add_action('enqueue_block_editor_assets', function () {
         'icon-shield.svg',
         'icon-users.svg',
         'icon-clock.svg',
+        // contact-section block
+        'icon-mail.svg',
         // service-hero block
         'icon-search.svg',
         // feature-cards block

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 2.11.1
+Stable tag: 2.12.0
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,17 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.12.0 - 04/24/26 =
+* ADDED: New `nynaeve/contact-section` block — full-width dark section with intro, two-column info/CF7-form-card layout, icon detail rows, and animated availability badge.
+* ADDED: `icon-mail.svg` theme icon (brand-blue stroke) registered for use in the contact-section block.
+* ADDED: CF7 form card renders a CSS Grid two-column name + email row; stacks to single column on mobile (≤860px).
+* ADDED: Responsive layout — form card above info column on tablet/mobile, reduced padding on small phones (≤520px).
+* ADDED: Decorative radial-gradient glow pseudo-elements on the contact section wrapper for visual depth.
+* ADDED: Block editor preview styles (`editor.css`) so dark background, grid, and form card are visible while editing.
+* ADDED: Section 16 in `app.css` — comprehensive Contact Form 7 global styles (inputs, textarea, select, submit button, validation tips, success/error banners).
+* ADDED: `.wpcf7-on-dark` CSS utility class for dark-background CF7 form variants (semi-transparent fields, white text, primary-color focus ring)."
+
 
 = 2.11.1 - 04/23/26 =
 * FIXED: Single post entry-meta mobile layout - restructured into two flex-nowrap groups (dates and author+category) so each wraps as a unit; author name and category tag now stay on the same line on mobile.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,6 +24,7 @@
  * 13. WooCommerce Product Page Content Styling
  * 14. Search Results Page
  * 15. Search Overlay
+ * 16. Contact Form 7 Styling
  */
 
 /* -----------------------------------------------------------------------------
@@ -1083,4 +1084,198 @@ body .gform_wrapper .gform_body {
   font-size: 0.8rem;
   text-align: center;
   letter-spacing: 0.02em;
+}
+
+/* -----------------------------------------------------------------------------
+ * 16. Contact Form 7 Styling
+ * -------------------------------------------------------------------------- */
+
+.wpcf7 {
+  font-family: var(--font-open-sans);
+}
+
+/* Labels */
+.wpcf7 label {
+  @apply block mb-1 font-medium text-sm;
+  color: var(--color-main);
+}
+
+/* Text, email, tel, number, URL inputs */
+.wpcf7 input[type="text"],
+.wpcf7 input[type="email"],
+.wpcf7 input[type="tel"],
+.wpcf7 input[type="number"],
+.wpcf7 input[type="url"],
+.wpcf7 input[type="date"],
+.wpcf7 input[type="search"] {
+  @apply block w-full px-4 py-3 border border-gray-300 rounded-lg
+    bg-gray-50 text-base transition duration-150
+    focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500;
+  color: var(--color-main);
+}
+
+/* Textarea */
+.wpcf7 textarea {
+  @apply block w-full px-4 py-3 border border-gray-300 rounded-lg
+    bg-gray-50 text-base resize-y transition duration-150
+    focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500;
+  color: var(--color-main);
+  min-height: 8rem;
+}
+
+/* Select */
+.wpcf7 select {
+  @apply block w-full px-4 py-3 border border-gray-300 rounded-lg
+    bg-gray-50 text-base transition duration-150
+    focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500;
+  color: var(--color-main);
+}
+
+/* Checkboxes and radio buttons */
+.wpcf7 .wpcf7-list-item {
+  @apply inline-flex items-center gap-2 mr-4 mb-1;
+}
+
+.wpcf7 input[type="checkbox"],
+.wpcf7 input[type="radio"] {
+  @apply w-4 h-4 border-gray-300 rounded;
+  accent-color: var(--color-primary);
+}
+
+/* Field control wrappers — ensure full width */
+.wpcf7 .wpcf7-form-control-wrap {
+  @apply block w-full;
+}
+
+/* Spacing between form rows */
+.wpcf7 p,
+.wpcf7 .wpcf7-form p {
+  @apply mb-5;
+  color: inherit;
+}
+
+/* Submit button */
+.wpcf7 input[type="submit"],
+.wpcf7 .wpcf7-submit {
+  @apply inline-flex items-center justify-center px-6 py-3 rounded-md
+    font-semibold text-white cursor-pointer border-none
+    shadow-sm transition-all duration-300;
+  font-size: var(--wp--preset--font-size--base);
+  background-color: var(--color-primary);
+}
+
+.wpcf7 input[type="submit"]:hover,
+.wpcf7 .wpcf7-submit:hover {
+  filter: brightness(0.9);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+}
+
+/* Spinner (loading indicator) */
+.wpcf7-spinner {
+  @apply inline-block ml-3 align-middle;
+}
+
+/* Inline validation error tip */
+.wpcf7-not-valid-tip {
+  @apply block mt-1 text-sm font-medium;
+  color: #dc2626;
+}
+
+/* Invalid field highlight */
+.wpcf7 input.wpcf7-not-valid,
+.wpcf7 textarea.wpcf7-not-valid,
+.wpcf7 select.wpcf7-not-valid {
+  @apply border-red-500 focus:ring-red-500 focus:border-red-500;
+}
+
+/* Response output (success / error banner) */
+.wpcf7-response-output {
+  @apply mt-4 px-4 py-3 rounded-lg border text-sm font-medium;
+}
+
+/* Success */
+.wpcf7-mail-sent-ok {
+  border-color: #22c55e;
+  background-color: #f0fdf4;
+  color: #15803d;
+}
+
+/* Validation / send error */
+.wpcf7-validation-errors,
+.wpcf7-mail-sent-ng,
+.wpcf7-spam-blocked {
+  border-color: #f97316;
+  background-color: #fff7ed;
+  color: #c2410c;
+}
+
+/* Dark background variant
+ * Add "wpcf7-on-dark" as an Additional CSS class on the wrapping group block
+ * to switch the form to a dark-adapted appearance.
+ */
+.wpcf7-on-dark .wpcf7,
+.wpcf7-on-dark.wpcf7 {
+  --wpcf7-input-bg: rgba(255, 255, 255, 0.08);
+  --wpcf7-input-border: rgba(255, 255, 255, 0.2);
+  --wpcf7-input-color: #ffffff;
+  --wpcf7-focus-ring: rgba(255, 255, 255, 0.4);
+}
+
+.wpcf7-on-dark .wpcf7 label,
+.wpcf7-on-dark.wpcf7 label {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.wpcf7-on-dark .wpcf7 input[type="text"],
+.wpcf7-on-dark .wpcf7 input[type="email"],
+.wpcf7-on-dark .wpcf7 input[type="tel"],
+.wpcf7-on-dark .wpcf7 input[type="number"],
+.wpcf7-on-dark .wpcf7 input[type="url"],
+.wpcf7-on-dark .wpcf7 input[type="date"],
+.wpcf7-on-dark .wpcf7 input[type="search"],
+.wpcf7-on-dark .wpcf7 textarea,
+.wpcf7-on-dark .wpcf7 select,
+.wpcf7-on-dark.wpcf7 input[type="text"],
+.wpcf7-on-dark.wpcf7 input[type="email"],
+.wpcf7-on-dark.wpcf7 input[type="tel"],
+.wpcf7-on-dark.wpcf7 input[type="number"],
+.wpcf7-on-dark.wpcf7 input[type="url"],
+.wpcf7-on-dark.wpcf7 input[type="date"],
+.wpcf7-on-dark.wpcf7 input[type="search"],
+.wpcf7-on-dark.wpcf7 textarea,
+.wpcf7-on-dark.wpcf7 select {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+.wpcf7-on-dark .wpcf7 input[type="text"]::placeholder,
+.wpcf7-on-dark .wpcf7 input[type="email"]::placeholder,
+.wpcf7-on-dark .wpcf7 textarea::placeholder,
+.wpcf7-on-dark.wpcf7 input[type="text"]::placeholder,
+.wpcf7-on-dark.wpcf7 input[type="email"]::placeholder,
+.wpcf7-on-dark.wpcf7 textarea::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.wpcf7-on-dark .wpcf7 input:focus,
+.wpcf7-on-dark .wpcf7 textarea:focus,
+.wpcf7-on-dark .wpcf7 select:focus,
+.wpcf7-on-dark.wpcf7 input:focus,
+.wpcf7-on-dark.wpcf7 textarea:focus,
+.wpcf7-on-dark.wpcf7 select:focus {
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(1, 124, 182, 0.4);
+}
+
+.wpcf7-on-dark .wpcf7-not-valid-tip,
+.wpcf7-on-dark.wpcf7 .wpcf7-not-valid-tip {
+  color: #fca5a5;
+}
+
+/* Column padding: when form is inside a dark group column, add breathing room */
+.wpcf7-on-dark .wpcf7 {
+  padding: 2rem;
 }

--- a/resources/images/icons/icon-mail.svg
+++ b/resources/images/icons/icon-mail.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" stroke="#017cb6" stroke-width="2"/>
+</svg>

--- a/resources/js/blocks/contact-section/block.json
+++ b/resources/js/blocks/contact-section/block.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "nynaeve/contact-section",
+    "version": "1.0.0",
+    "title": "Contact Section",
+    "category": "text",
+    "icon": "email",
+    "description": "Dark contact section with info column and Contact Form 7 form card.",
+    "keywords": ["contact", "form", "cf7", "section"],
+    "example": {},
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"],
+        "anchor": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        }
+    },
+    "textdomain": "nynaeve",
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css",
+    "viewScript": "file:./view.js",
+    "attributes": {
+        "align": {
+            "type": "string",
+            "default": "full"
+        },
+        "style": {
+            "type": "object",
+            "default": {
+                "spacing": {
+                    "margin": { "top": "0", "bottom": "0" }
+                }
+            }
+        }
+    }
+}

--- a/resources/js/blocks/contact-section/block.json
+++ b/resources/js/blocks/contact-section/block.json
@@ -4,7 +4,7 @@
     "name": "nynaeve/contact-section",
     "version": "1.0.0",
     "title": "Contact Section",
-    "category": "text",
+    "category": "nynaeve/cta",
     "icon": "email",
     "description": "Dark contact section with info column and Contact Form 7 form card.",
     "keywords": ["contact", "form", "cf7", "section"],

--- a/resources/js/blocks/contact-section/editor.css
+++ b/resources/js/blocks/contact-section/editor.css
@@ -6,7 +6,7 @@
 
 /* Force two-column layout visible in editor */
 .wp-block-nynaeve-contact-section .contact-section__grid {
-  display: grid !important;
+  display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 48px;
   align-items: start;

--- a/resources/js/blocks/contact-section/editor.css
+++ b/resources/js/blocks/contact-section/editor.css
@@ -1,0 +1,38 @@
+/* Show dark section background in the block editor */
+.wp-block-nynaeve-contact-section {
+  background: var(--wp--preset--color--main, #171b23);
+  padding: 60px 24px;
+}
+
+/* Force two-column layout visible in editor */
+.wp-block-nynaeve-contact-section .contact-section__grid {
+  display: grid !important;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: start;
+}
+
+/* Make text readable on dark background in editor */
+.wp-block-nynaeve-contact-section .wp-block-heading,
+.wp-block-nynaeve-contact-section .wp-block-paragraph {
+  color: rgba(255,255,255,0.9);
+}
+
+/* Keep intro centered */
+.wp-block-nynaeve-contact-section .contact-section__intro {
+  text-align: center;
+}
+
+/* Keep the form card visible in editor */
+.wp-block-nynaeve-contact-section .contact-section__card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: 12px;
+  padding: 32px 28px;
+}
+
+/* Suppress glow pseudo-elements in editor (they don't display anyway) */
+.wp-block-nynaeve-contact-section::before,
+.wp-block-nynaeve-contact-section::after {
+  display: none;
+}

--- a/resources/js/blocks/contact-section/editor.css
+++ b/resources/js/blocks/contact-section/editor.css
@@ -1,6 +1,6 @@
 /* Show dark section background in the block editor */
 .wp-block-nynaeve-contact-section {
-  background: var(--wp--preset--color--main, #171b23);
+  background: var(--wp--preset--color--main);
   padding: 60px 24px;
 }
 

--- a/resources/js/blocks/contact-section/editor.jsx
+++ b/resources/js/blocks/contact-section/editor.jsx
@@ -1,0 +1,172 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+const icons = window.imagewizeIcons ?? {};
+
+function iconImage(path, alt) {
+  return [
+    'core/image',
+    {
+      url: icons[path] ?? '',
+      alt,
+      sizeSlug: 'full',
+      linkDestination: 'none',
+      metadata: {
+        bindings: {
+          url: { source: 'imagewize/theme-icon', args: { path } },
+        },
+      },
+    },
+  ];
+}
+
+function detailItem(iconPath, iconAlt, label, value) {
+  return [
+    'core/group',
+    {
+      className: 'cs-detail',
+      layout: { type: 'flex', orientation: 'horizontal', flexWrap: 'nowrap', verticalAlignment: 'top' },
+    },
+    [
+      [
+        'core/group',
+        {
+          className: 'cs-detail__icon',
+          layout: { type: 'flex', justifyContent: 'center', verticalAlignment: 'center' },
+        },
+        [ iconImage(iconPath, iconAlt) ],
+      ],
+      [
+        'core/group',
+        {
+          className: 'cs-detail__body',
+          layout: { type: 'constrained' },
+          style: { spacing: { blockGap: '4px' } },
+        },
+        [
+          ['core/paragraph', { className: 'cs-detail__label', content: label }],
+          ['core/paragraph', { className: 'cs-detail__value', content: value }],
+        ],
+      ],
+    ],
+  ];
+}
+
+const TEMPLATE = [
+  // ─── INTRO ───────────────────────────────────────────────────────────
+  [
+    'core/group',
+    {
+      className: 'contact-section__intro',
+      layout: { type: 'constrained' },
+      style: { spacing: { blockGap: '16px' } },
+    },
+    [
+      ['core/paragraph', { className: 'contact-section__label', content: 'Contact us' }],
+      [
+        'core/heading',
+        {
+          level: 2,
+          className: 'contact-section__heading',
+          content: "Let's build something <em>fast &amp; scalable.</em>",
+        },
+      ],
+      [
+        'core/paragraph',
+        {
+          className: 'contact-section__sub',
+          content:
+            "Whether you need a powerful WordPress site, WooCommerce store, speed optimisation, or ongoing maintenance — we're here to help.",
+        },
+      ],
+    ],
+  ],
+
+  // ─── TWO-COLUMN GRID ─────────────────────────────────────────────────
+  [
+    'core/group',
+    {
+      className: 'contact-section__grid',
+      layout: { type: 'flex', orientation: 'horizontal', flexWrap: 'nowrap', verticalAlignment: 'top' },
+    },
+    [
+      // LEFT: contact info
+      [
+        'core/group',
+        {
+          className: 'contact-section__info',
+          layout: { type: 'constrained' },
+          style: { spacing: { blockGap: '16px' } },
+        },
+        [
+          [
+            'core/heading',
+            {
+              level: 3,
+              className: 'contact-section__info-heading',
+              content: 'Talk to an expert,<br>not a salesperson.',
+            },
+          ],
+          [
+            'core/paragraph',
+            {
+              className: 'contact-section__info-text',
+              content:
+                "Send us a message and one of our WordPress specialists will get back to you within one business day. We work with SMEs across the Netherlands Western Europe, Australia and the US.",
+            },
+          ],
+          // Detail items with theme-icon SVGs
+          [
+            'core/group',
+            {
+              className: 'contact-section__details',
+              layout: { type: 'flex', orientation: 'vertical' },
+              style: { spacing: { blockGap: '20px' } },
+            },
+            [
+              detailItem('icon-mail.svg',  'Email',         'Email',         'hello@imagewize.com'),
+              detailItem('icon-clock.svg', 'Response time', 'Response time', 'Within 1 business day'),
+              detailItem('icon-map.svg',   'Location',      'Based in',      'Asia — serving Europe, Australia and the US'),
+            ],
+          ],
+          // "Available for new projects" badge — dot rendered via CSS ::before
+          [
+            'core/group',
+            {
+              className: 'cs-badge',
+              layout: { type: 'flex', orientation: 'horizontal', flexWrap: 'nowrap', verticalAlignment: 'center' },
+            },
+            [
+              ['core/paragraph', { className: 'cs-badge__text', content: 'Available for new projects' }],
+            ],
+          ],
+        ],
+      ],
+
+      // RIGHT: CF7 form card
+      [
+        'core/group',
+        {
+          className: 'contact-section__card',
+          layout: { type: 'constrained' },
+        },
+        [
+          ['core/shortcode', { text: '[contact-form-7 id="FORM_ID" title="Contact form 1"]' }],
+        ],
+      ],
+    ],
+  ],
+];
+
+export default function Edit() {
+  const blockProps = useBlockProps({
+    className: 'wp-block-nynaeve-contact-section',
+  });
+
+  return (
+    <div {...blockProps}>
+      <div className="contact-section__inner">
+        <InnerBlocks template={TEMPLATE} templateLock={false} />
+      </div>
+    </div>
+  );
+}

--- a/resources/js/blocks/contact-section/index.js
+++ b/resources/js/blocks/contact-section/index.js
@@ -1,0 +1,11 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import metadata from './block.json';
+import Edit from './editor.jsx';
+import Save from './save.jsx';
+
+registerBlockType(metadata.name, {
+  ...metadata,
+  edit: Edit,
+  save: Save,
+});

--- a/resources/js/blocks/contact-section/save.jsx
+++ b/resources/js/blocks/contact-section/save.jsx
@@ -1,0 +1,15 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+export default function Save() {
+  const blockProps = useBlockProps.save({
+    className: 'wp-block-nynaeve-contact-section',
+  });
+
+  return (
+    <div {...blockProps}>
+      <div className="contact-section__inner">
+        <InnerBlocks.Content />
+      </div>
+    </div>
+  );
+}

--- a/resources/js/blocks/contact-section/style.css
+++ b/resources/js/blocks/contact-section/style.css
@@ -1,6 +1,6 @@
 /* ─── SECTION WRAPPER ─── */
 .wp-block-nynaeve-contact-section {
-  background: var(--wp--preset--color--main, #171b23);
+  background: var(--wp--preset--color--main);
   padding: 90px 24px 100px;
   position: relative;
   overflow: hidden;
@@ -60,7 +60,7 @@
 .wp-block-nynaeve-contact-section .contact-section__heading {
   font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 700;
-  color: var(--wp--preset--color--base, #ffffff);
+  color: var(--wp--preset--color--base);
   line-height: 1.15;
   margin-bottom: 20px;
   text-align: center;
@@ -109,7 +109,7 @@
 .wp-block-nynaeve-contact-section .contact-section__info-heading {
   font-size: 1.35rem;
   font-weight: 700;
-  color: var(--wp--preset--color--base, #ffffff);
+  color: var(--wp--preset--color--base);
   margin-bottom: 16px;
 }
 
@@ -357,7 +357,7 @@
   border-radius: 6px;
   font-size: 0.88rem;
   border: 1px solid rgba(1,124,182,0.40);
-  color: var(--wp--preset--color--primary-accent, #e6f4fb);
+  color: var(--wp--preset--color--primary-accent);
   background: rgba(1,124,182,0.10);
   margin-top: 0;
 }

--- a/resources/js/blocks/contact-section/style.css
+++ b/resources/js/blocks/contact-section/style.css
@@ -1,0 +1,395 @@
+/* ─── SECTION WRAPPER ─── */
+.wp-block-nynaeve-contact-section {
+  background: var(--wp--preset--color--main, #171b23);
+  padding: 90px 24px 100px;
+  position: relative;
+  overflow: hidden;
+}
+
+.wp-block-nynaeve-contact-section::before {
+  content: '';
+  position: absolute;
+  top: -180px;
+  right: -180px;
+  width: 560px;
+  height: 560px;
+  background: radial-gradient(circle, rgba(1,124,182,0.18) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.wp-block-nynaeve-contact-section::after {
+  content: '';
+  position: absolute;
+  bottom: -120px;
+  left: -120px;
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, rgba(1,124,182,0.10) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.contact-section__inner {
+  max-width: 1280px;
+  margin-inline: auto;
+  position: relative;
+  z-index: 1;
+}
+
+/* ─── INTRO ─── */
+.contact-section__intro {
+  text-align: center;
+  margin-bottom: 64px !important;
+}
+
+.contact-section__intro > * {
+  margin-top: 0 !important;
+}
+
+.contact-section__label {
+  display: inline-block;
+  font-size: 11px !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--wp--preset--color--primary, #017cb6) !important;
+  margin-bottom: 16px !important;
+}
+
+.contact-section__heading {
+  font-size: clamp(2rem, 4vw, 3rem) !important;
+  font-weight: 700 !important;
+  color: var(--wp--preset--color--base, #ffffff) !important;
+  line-height: 1.15 !important;
+  margin-bottom: 20px !important;
+  text-align: center;
+}
+
+.contact-section__heading em {
+  color: var(--wp--preset--color--primary, #017cb6);
+  font-style: normal;
+}
+
+.contact-section__sub {
+  font-size: 1.05rem !important;
+  color: rgba(255,255,255,0.55) !important;
+  max-width: 560px;
+  margin-inline: auto !important;
+  line-height: 1.7 !important;
+  text-align: center;
+}
+
+/* ─── TWO-COLUMN GRID ─── */
+.contact-section__grid {
+  display: grid !important;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: start;
+  /* reset WordPress flex overrides */
+  flex-wrap: unset !important;
+  justify-content: unset !important;
+}
+
+.contact-section__grid > * {
+  flex: unset !important;
+  margin-top: 0 !important;
+  min-width: 0;
+}
+
+/* ─── LEFT COL: INFO ─── */
+.contact-section__info {
+  padding-top: 8px;
+}
+
+.contact-section__info > * {
+  margin-top: 0 !important;
+}
+
+.contact-section__info-heading {
+  font-size: 1.35rem !important;
+  font-weight: 700 !important;
+  color: var(--wp--preset--color--base, #ffffff) !important;
+  margin-bottom: 16px !important;
+}
+
+.contact-section__info-text {
+  font-size: 0.97rem !important;
+  color: rgba(255,255,255,0.55) !important;
+  line-height: 1.75 !important;
+  margin-bottom: 40px !important;
+}
+
+/* Detail items */
+.contact-section__details {
+  gap: 20px;
+}
+
+.contact-section__details > * {
+  margin-top: 0 !important;
+}
+
+.cs-detail {
+  gap: 16px;
+  flex-wrap: nowrap !important;
+}
+
+.cs-detail > * {
+  margin-top: 0 !important;
+}
+
+.cs-detail__icon {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0 !important;
+  flex-grow: 0 !important;
+  border-radius: 8px;
+  background: rgba(1,124,182,0.15);
+  border: 1px solid rgba(1,124,182,0.30);
+}
+
+/* core/image inside icon box */
+.cs-detail__icon .wp-block-image {
+  margin: 0;
+  line-height: 0;
+}
+
+.cs-detail__icon .wp-block-image img {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+.cs-detail__body {
+  min-width: 0;
+}
+
+.cs-detail__body > * {
+  margin-top: 0 !important;
+}
+
+.cs-detail__label {
+  font-size: 11px !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.35) !important;
+  margin-bottom: 3px !important;
+}
+
+.cs-detail__value {
+  font-size: 0.93rem !important;
+  color: rgba(255,255,255,0.80) !important;
+}
+
+/* Available badge — green dot via ::before (safe on div, not contenteditable) */
+.cs-badge {
+  display: inline-flex !important;
+  align-items: center;
+  gap: 8px;
+  margin-top: 36px !important;
+  padding: 10px 18px;
+  border-radius: 100px;
+  background: rgba(1,124,182,0.12);
+  border: 1px solid rgba(1,124,182,0.30);
+  width: fit-content;
+}
+
+.cs-badge::before {
+  content: '';
+  display: block;
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34,197,94,0.20);
+  animation: cs-pulse 2s ease-in-out infinite;
+}
+
+@keyframes cs-pulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(34,197,94,0.20); }
+  50%       { box-shadow: 0 0 0 6px rgba(34,197,94,0.08); }
+}
+
+.cs-badge__text {
+  font-size: 0.82rem !important;
+  font-weight: 600 !important;
+  color: rgba(255,255,255,0.65) !important;
+  margin: 0 !important;
+}
+
+/* ─── RIGHT COL: FORM CARD ─── */
+.contact-section__card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: 12px;
+  padding: 40px 36px;
+  backdrop-filter: blur(6px);
+}
+
+.contact-section__card > * {
+  margin-top: 0 !important;
+}
+
+/* CF7 form: CSS Grid for two-column name + email row */
+.contact-section__card form {
+  display: grid !important;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 16px;
+  row-gap: 20px;
+  align-items: start;
+}
+
+/* Hidden CF7 honeypot fieldset */
+.contact-section__card form fieldset.hidden-fields-container {
+  display: none;
+}
+
+/* All field <p> wrappers: full-width by default */
+.contact-section__card form > p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+/* First two fields (name + email): one column each, side by side */
+.contact-section__card form > p:nth-of-type(1),
+.contact-section__card form > p:nth-of-type(2) {
+  grid-column: auto;
+}
+
+/* CF7 label wraps both the label text and the input via <br> —
+   use flex column + hide <br> to get proper label-to-input spacing */
+.wp-block-nynaeve-contact-section .contact-section__card label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.45);
+  margin: 0;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card label br {
+  display: none;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card .wpcf7-form-control-wrap {
+  display: block;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card input[type="text"],
+.wp-block-nynaeve-contact-section .contact-section__card input[type="email"],
+.wp-block-nynaeve-contact-section .contact-section__card input[type="tel"],
+.wp-block-nynaeve-contact-section .contact-section__card input[type="url"],
+.wp-block-nynaeve-contact-section .contact-section__card select,
+.wp-block-nynaeve-contact-section .contact-section__card textarea {
+  width: 100%;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 6px;
+  padding: 13px 16px;
+  font-size: 0.92rem;
+  color: #ffffff;
+  outline: none;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+  -webkit-appearance: none;
+  appearance: none;
+  box-shadow: none;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card input::placeholder,
+.wp-block-nynaeve-contact-section .contact-section__card textarea::placeholder {
+  color: rgba(255,255,255,0.25);
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card input:focus,
+.wp-block-nynaeve-contact-section .contact-section__card textarea:focus,
+.wp-block-nynaeve-contact-section .contact-section__card select:focus {
+  border-color: var(--wp--preset--color--primary, #017cb6);
+  background: rgba(1,124,182,0.25);
+  box-shadow: 0 0 0 3px rgba(1,124,182,0.15);
+  outline: none;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card textarea {
+  resize: vertical;
+  min-height: 130px;
+  line-height: 1.6;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card input[type="submit"] {
+  width: 100%;
+  padding: 15px 48px 15px 24px;
+  background-color: var(--wp--preset--color--primary, #017cb6);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 20px center;
+  color: #ffffff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.15s, box-shadow 0.2s;
+  margin-top: 4px;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card input[type="submit"]:hover {
+  background-color: var(--wp--preset--color--primary-dark, #026492);
+  box-shadow: 0 6px 24px rgba(1,124,182,0.35);
+  transform: translateY(-1px);
+}
+
+/* CF7 validation messages */
+.wp-block-nynaeve-contact-section .contact-section__card .wpcf7-not-valid-tip {
+  font-size: 0.78rem;
+  color: #f87171;
+  margin-top: 4px;
+}
+
+.wp-block-nynaeve-contact-section .contact-section__card .wpcf7-response-output {
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 0.88rem;
+  border: 1px solid rgba(1,124,182,0.40);
+  color: var(--wp--preset--color--primary-accent, #e6f4fb);
+  background: rgba(1,124,182,0.10);
+  margin-top: 0;
+}
+
+/* ─── RESPONSIVE ─── */
+@media (max-width: 860px) {
+  .contact-section__grid {
+    grid-template-columns: 1fr !important;
+    gap: 52px;
+  }
+
+  .contact-section__info {
+    order: 2;
+  }
+
+  .contact-section__card {
+    order: 1;
+  }
+
+  /* Stack name + email fields on mobile */
+  .contact-section__card form > p:nth-of-type(1),
+  .contact-section__card form > p:nth-of-type(2) {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 520px) {
+  .wp-block-nynaeve-contact-section {
+    padding: 60px 20px 72px;
+  }
+
+  .contact-section__card {
+    padding: 28px 20px;
+  }
+}

--- a/resources/js/blocks/contact-section/style.css
+++ b/resources/js/blocks/contact-section/style.css
@@ -30,7 +30,7 @@
   z-index: 0;
 }
 
-.contact-section__inner {
+.wp-block-nynaeve-contact-section .contact-section__inner {
   max-width: 1280px;
   margin-inline: auto;
   position: relative;
@@ -38,156 +38,156 @@
 }
 
 /* ─── INTRO ─── */
-.contact-section__intro {
+.wp-block-nynaeve-contact-section .contact-section__intro {
   text-align: center;
-  margin-bottom: 64px !important;
+  margin-bottom: 64px;
 }
 
-.contact-section__intro > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .contact-section__intro > * {
+  margin-top: 0;
 }
 
-.contact-section__label {
+.wp-block-nynaeve-contact-section .contact-section__label {
   display: inline-block;
-  font-size: 11px !important;
-  font-weight: 600 !important;
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--wp--preset--color--primary, #017cb6) !important;
-  margin-bottom: 16px !important;
+  color: var(--wp--preset--color--primary);
+  margin-bottom: 16px;
 }
 
-.contact-section__heading {
-  font-size: clamp(2rem, 4vw, 3rem) !important;
-  font-weight: 700 !important;
-  color: var(--wp--preset--color--base, #ffffff) !important;
-  line-height: 1.15 !important;
-  margin-bottom: 20px !important;
+.wp-block-nynaeve-contact-section .contact-section__heading {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--wp--preset--color--base, #ffffff);
+  line-height: 1.15;
+  margin-bottom: 20px;
   text-align: center;
 }
 
-.contact-section__heading em {
-  color: var(--wp--preset--color--primary, #017cb6);
+.wp-block-nynaeve-contact-section .contact-section__heading em {
+  color: var(--wp--preset--color--primary);
   font-style: normal;
 }
 
-.contact-section__sub {
-  font-size: 1.05rem !important;
-  color: rgba(255,255,255,0.55) !important;
+.wp-block-nynaeve-contact-section .contact-section__sub {
+  font-size: 1.05rem;
+  color: rgba(255,255,255,0.55);
   max-width: 560px;
-  margin-inline: auto !important;
-  line-height: 1.7 !important;
+  margin-inline: auto;
+  line-height: 1.7;
   text-align: center;
 }
 
 /* ─── TWO-COLUMN GRID ─── */
-.contact-section__grid {
-  display: grid !important;
+.wp-block-nynaeve-contact-section .contact-section__grid {
+  display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 48px;
   align-items: start;
   /* reset WordPress flex overrides */
-  flex-wrap: unset !important;
-  justify-content: unset !important;
+  flex-wrap: unset;
+  justify-content: unset;
 }
 
-.contact-section__grid > * {
-  flex: unset !important;
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .contact-section__grid > * {
+  flex: unset;
+  margin-top: 0;
   min-width: 0;
 }
 
 /* ─── LEFT COL: INFO ─── */
-.contact-section__info {
+.wp-block-nynaeve-contact-section .contact-section__info {
   padding-top: 8px;
 }
 
-.contact-section__info > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .contact-section__info > * {
+  margin-top: 0;
 }
 
-.contact-section__info-heading {
-  font-size: 1.35rem !important;
-  font-weight: 700 !important;
-  color: var(--wp--preset--color--base, #ffffff) !important;
-  margin-bottom: 16px !important;
+.wp-block-nynaeve-contact-section .contact-section__info-heading {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--wp--preset--color--base, #ffffff);
+  margin-bottom: 16px;
 }
 
-.contact-section__info-text {
-  font-size: 0.97rem !important;
-  color: rgba(255,255,255,0.55) !important;
-  line-height: 1.75 !important;
-  margin-bottom: 40px !important;
+.wp-block-nynaeve-contact-section .contact-section__info-text {
+  font-size: 0.97rem;
+  color: rgba(255,255,255,0.55);
+  line-height: 1.75;
+  margin-bottom: 40px;
 }
 
 /* Detail items */
-.contact-section__details {
+.wp-block-nynaeve-contact-section .contact-section__details {
   gap: 20px;
 }
 
-.contact-section__details > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .contact-section__details > * {
+  margin-top: 0;
 }
 
-.cs-detail {
+.wp-block-nynaeve-contact-section .cs-detail {
   gap: 16px;
-  flex-wrap: nowrap !important;
+  flex-wrap: nowrap;
 }
 
-.cs-detail > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .cs-detail > * {
+  margin-top: 0;
 }
 
-.cs-detail__icon {
+.wp-block-nynaeve-contact-section .cs-detail__icon {
   width: 42px;
   height: 42px;
-  flex-shrink: 0 !important;
-  flex-grow: 0 !important;
+  flex-shrink: 0;
+  flex-grow: 0;
   border-radius: 8px;
   background: rgba(1,124,182,0.15);
   border: 1px solid rgba(1,124,182,0.30);
 }
 
 /* core/image inside icon box */
-.cs-detail__icon .wp-block-image {
+.wp-block-nynaeve-contact-section .cs-detail__icon .wp-block-image {
   margin: 0;
   line-height: 0;
 }
 
-.cs-detail__icon .wp-block-image img {
+.wp-block-nynaeve-contact-section .cs-detail__icon .wp-block-image img {
   width: 18px;
   height: 18px;
   display: block;
 }
 
-.cs-detail__body {
+.wp-block-nynaeve-contact-section .cs-detail__body {
   min-width: 0;
 }
 
-.cs-detail__body > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .cs-detail__body > * {
+  margin-top: 0;
 }
 
-.cs-detail__label {
-  font-size: 11px !important;
-  font-weight: 600 !important;
+.wp-block-nynaeve-contact-section .cs-detail__label {
+  font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.35) !important;
-  margin-bottom: 3px !important;
+  color: rgba(255,255,255,0.35);
+  margin-bottom: 3px;
 }
 
-.cs-detail__value {
-  font-size: 0.93rem !important;
-  color: rgba(255,255,255,0.80) !important;
+.wp-block-nynaeve-contact-section .cs-detail__value {
+  font-size: 0.93rem;
+  color: rgba(255,255,255,0.80);
 }
 
 /* Available badge — green dot via ::before (safe on div, not contenteditable) */
-.cs-badge {
-  display: inline-flex !important;
+.wp-block-nynaeve-contact-section .cs-badge {
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin-top: 36px !important;
+  margin-top: 36px;
   padding: 10px 18px;
   border-radius: 100px;
   background: rgba(1,124,182,0.12);
@@ -195,7 +195,7 @@
   width: fit-content;
 }
 
-.cs-badge::before {
+.wp-block-nynaeve-contact-section .cs-badge::before {
   content: '';
   display: block;
   width: 8px;
@@ -212,15 +212,15 @@
   50%       { box-shadow: 0 0 0 6px rgba(34,197,94,0.08); }
 }
 
-.cs-badge__text {
-  font-size: 0.82rem !important;
-  font-weight: 600 !important;
-  color: rgba(255,255,255,0.65) !important;
-  margin: 0 !important;
+.wp-block-nynaeve-contact-section .cs-badge__text {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.65);
+  margin: 0;
 }
 
 /* ─── RIGHT COL: FORM CARD ─── */
-.contact-section__card {
+.wp-block-nynaeve-contact-section .contact-section__card {
   background: rgba(255,255,255,0.04);
   border: 1px solid rgba(255,255,255,0.10);
   border-radius: 12px;
@@ -228,13 +228,13 @@
   backdrop-filter: blur(6px);
 }
 
-.contact-section__card > * {
-  margin-top: 0 !important;
+.wp-block-nynaeve-contact-section .contact-section__card > * {
+  margin-top: 0;
 }
 
 /* CF7 form: CSS Grid for two-column name + email row */
-.contact-section__card form {
-  display: grid !important;
+.wp-block-nynaeve-contact-section .contact-section__card form {
+  display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: 16px;
   row-gap: 20px;
@@ -242,19 +242,19 @@
 }
 
 /* Hidden CF7 honeypot fieldset */
-.contact-section__card form fieldset.hidden-fields-container {
+.wp-block-nynaeve-contact-section .contact-section__card form fieldset.hidden-fields-container {
   display: none;
 }
 
 /* All field <p> wrappers: full-width by default */
-.contact-section__card form > p {
+.wp-block-nynaeve-contact-section .contact-section__card form > p {
   grid-column: 1 / -1;
   margin: 0;
 }
 
 /* First two fields (name + email): one column each, side by side */
-.contact-section__card form > p:nth-of-type(1),
-.contact-section__card form > p:nth-of-type(2) {
+.wp-block-nynaeve-contact-section .contact-section__card form > p:nth-of-type(1),
+.wp-block-nynaeve-contact-section .contact-section__card form > p:nth-of-type(2) {
   grid-column: auto;
 }
 
@@ -308,7 +308,7 @@
 .wp-block-nynaeve-contact-section .contact-section__card input:focus,
 .wp-block-nynaeve-contact-section .contact-section__card textarea:focus,
 .wp-block-nynaeve-contact-section .contact-section__card select:focus {
-  border-color: var(--wp--preset--color--primary, #017cb6);
+  border-color: var(--wp--preset--color--primary);
   background: rgba(1,124,182,0.25);
   box-shadow: 0 0 0 3px rgba(1,124,182,0.15);
   outline: none;
@@ -323,7 +323,7 @@
 .wp-block-nynaeve-contact-section .contact-section__card input[type="submit"] {
   width: 100%;
   padding: 15px 48px 15px 24px;
-  background-color: var(--wp--preset--color--primary, #017cb6);
+  background-color: var(--wp--preset--color--primary);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 20px center;
@@ -364,22 +364,22 @@
 
 /* ─── RESPONSIVE ─── */
 @media (max-width: 860px) {
-  .contact-section__grid {
-    grid-template-columns: 1fr !important;
+  .wp-block-nynaeve-contact-section .contact-section__grid {
+    grid-template-columns: 1fr;
     gap: 52px;
   }
 
-  .contact-section__info {
+  .wp-block-nynaeve-contact-section .contact-section__info {
     order: 2;
   }
 
-  .contact-section__card {
+  .wp-block-nynaeve-contact-section .contact-section__card {
     order: 1;
   }
 
   /* Stack name + email fields on mobile */
-  .contact-section__card form > p:nth-of-type(1),
-  .contact-section__card form > p:nth-of-type(2) {
+  .wp-block-nynaeve-contact-section .contact-section__card form > p:nth-of-type(1),
+  .wp-block-nynaeve-contact-section .contact-section__card form > p:nth-of-type(2) {
     grid-column: 1 / -1;
   }
 }
@@ -389,7 +389,7 @@
     padding: 60px 20px 72px;
   }
 
-  .contact-section__card {
+  .wp-block-nynaeve-contact-section .contact-section__card {
     padding: 28px 20px;
   }
 }

--- a/resources/js/blocks/contact-section/style.css
+++ b/resources/js/blocks/contact-section/style.css
@@ -340,7 +340,7 @@
 }
 
 .wp-block-nynaeve-contact-section .contact-section__card input[type="submit"]:hover {
-  background-color: var(--wp--preset--color--primary-dark, #026492);
+  background-color: var(--wp--preset--color--primary-dark);
   box-shadow: 0 6px 24px rgba(1,124,182,0.35);
   transform: translateY(-1px);
 }

--- a/resources/js/blocks/contact-section/view.js
+++ b/resources/js/blocks/contact-section/view.js
@@ -1,0 +1,1 @@
+// Pulse animation on .cs-badge__dot is handled entirely by CSS.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.11.1
+Version: 2.12.0
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
This PR introduces the `nynaeve/contact-section` Sage Native block — a full-width, dark-themed contact section designed to integrate Contact Form 7 into the WordPress block editor. The block follows the project's InnerBlocks-first philosophy, composing the entire layout from native core blocks (headings, paragraphs, groups, shortcode) within a locked-flexible template, which preserves editor usability while maintaining visual consistency. A new `icon-mail.svg` asset is added and registered in `app/setup.php` via the established `imagewize/theme-icon` block binding pattern, ensuring the icon URL remains stable across Vite rebuilds. CSS across `style.css` and `editor.css` provides a fully responsive two-column layout on the frontend and an accurate editor preview, with a final refinement removing a hardcoded hex color fallback from the submit-button hover state in favour of the `--wp--preset--color--primary-dark` design token.

**Block Architecture and Template Structure:**
- The block renders a centered intro section above a two-column CSS Grid, with the CF7 form card on the right and contact detail items (email, response time, location) on the left, each using a theme-icon SVG in a styled icon box.
- The InnerBlocks template uses `templateLock: false` to allow editorial flexibility while shipping with production-ready default content; the form column embeds CF7 via `core/shortcode` so editors can swap form IDs without leaving the block.
- An "Available for new projects" availability badge uses a `::before` pseudo-element on a `core/group` container (not a `contenteditable` target), consistent with the project's flex-plus-pseudo-element safety rules.

**Styling and Responsive Behaviour:**
- `style.css` applies `alignfull` defaults with zero top/bottom margin via `block.json` attributes, preventing the 24px WP layout gap; decorative radial-gradient glows are added via `::before`/`::after` on the section wrapper and suppressed in `editor.css`.
- The CF7 form is styled using CSS Grid with a two-column name/email row that collapses to single-column below 860 px; below 520 px, section and card padding are reduced for small screens.
- Focus states and the submit button use `var(--wp--preset--color--primary)` and `var(--wp--preset--color--primary-dark)` exclusively, with no hardcoded fallback colors, keeping the block fully aligned with the theme's design token system.

**Icon Registration and Asset Pipeline:**
- `icon-mail.svg` is registered in the `app/setup.php` icon map under the `contact-section block` comment, making it available to both the editor (via `window.imagewizeIcons`) and the frontend (via the `imagewize/theme-icon` binding source calling `Vite::asset()` at render time).
- The block is categorised under `nynaeve/cta` in `block.json`, consistent with the theme's semantic category taxonomy for call-to-action blocks.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/contact-section/CHANGELOG.md) (Modified)
- [`app/setup.php`](https://github.com/imagewize/nynaeve/blob/contact-section/app/setup.php) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/contact-section/readme.txt) (Modified)
- [`resources/css/app.css`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/css/app.css) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/contact-section/style.css) (Modified)
- [`resources/images/icons/icon-mail.svg`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/images/icons/icon-mail.svg) (Added)
- [`resources/js/blocks/contact-section/block.json`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/block.json) (Added)
- [`resources/js/blocks/contact-section/editor.css`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/editor.css) (Added)
- [`resources/js/blocks/contact-section/editor.jsx`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/editor.jsx) (Added)
- [`resources/js/blocks/contact-section/index.js`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/index.js) (Added)
- [`resources/js/blocks/contact-section/save.jsx`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/save.jsx) (Added)
- [`resources/js/blocks/contact-section/style.css`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/style.css) (Added)
- [`resources/js/blocks/contact-section/view.js`](https://github.com/imagewize/nynaeve/blob/contact-section/resources/js/blocks/contact-section/view.js) (Added)