### PR TITLE
imagewize/theme-icon Block Binding Fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - `block.json`: namespace/category/textdomain `imagewize`; default align `wide`; button styles via `core/buttons` container class (not individual buttons); add `"example": {}` for an inserter preview.
 - Full-width (`alignfull`) blocks: set a default margin reset in `block.json` attributes (`"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}`) — NOT a CSS override — so the constrained-layout `margin-block-start` gap is removed while users keep spacing control. Applies only to newly inserted blocks; existing ones must be updated manually.
 - Blade views in `resources/views`; reuse via `partials/` and `sections/`. CSS is Tailwind-first, custom in `resources/css` or block `style.css`.
+- SVG icons in blocks: never `import` SVGs (Vite hashes them → stale URLs). Use the `imagewize/theme-icon` binding + `window.imagewizeIcons` (both from `app/setup.php`). `vite.config.js` MUST keep `assets: ['resources/images/**']` on the `laravel()` plugin so `Vite::asset()` can resolve the icons — without it every icon renders broken in editor and frontend. See CLAUDE.md "SVG Icons in Block Templates" and `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md`.
 
 ### WooCommerce Customization
 - Quote-based system (no cart/checkout); custom templates in `resources/views/woocommerce/`; "Request Quote" buttons replace add-to-cart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.15.3] - 2026-07-03
+
+### Fixed - Theme icon binding broken by Vite asset hashing
+
+**SVG Icon Rendering:**
+- Fixed all `imagewize/theme-icon` block binding icons rendering as broken images in both the block editor and on the frontend
+- Root cause: the static SVG icons in `resources/images/` were not part of the Vite build manifest, so `Vite::asset()` threw, the binding callback returned `null`, and `window.imagewizeIcons` values became empty strings
+
+### Technical - Vite build configuration for theme icons
+
+**vite.config.js:**
+- Added `assets: ['resources/images/**']` to the `laravel()` plugin so static SVG icons referenced only via `Vite::asset()` receive manifest entries
+- This is the supported mechanism for `laravel-vite-plugin` v3+ / Vite 8, replacing the old `import.meta.glob` approach
+
+**Documentation:**
+- Updated `CLAUDE.md`, `AGENTS.md`, and `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md` to document that `vite.config.js` must keep the `assets` option for the theme-icon binding to work
+- Added guidance: never `import` SVGs in blocks (Vite hashes them into stale URLs); always use the `imagewize/theme-icon` binding with `window.imagewizeIcons`
+
 ## [2.15.2] - 2026-06-30
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,22 @@ See [docs/ACF-BLOCKS.md](docs/ACF-BLOCKS.md).
 2. `app/setup.php` injects `window.imagewizeIcons` (key → current Vite URL) for editor display.
 3. `editor.jsx` uses `window.imagewizeIcons[path]` for `url` + adds `metadata.bindings.url` for frontend.
 
+**REQUIRED — `vite.config.js` must build the icons (CRITICAL):**
+For `Vite::asset('resources/images/icons/*.svg')` to resolve, the icons must be
+in the build manifest. They are not imported from any JS/CSS, so the `laravel()`
+plugin needs the `assets` option:
+```js
+laravel({
+  input: [ /* ... */ ],
+  assets: ['resources/images/**'],   // emits icons into the manifest
+  refresh: true,
+}),
+```
+This is the supported mechanism for `laravel-vite-plugin` v3+ / Vite 8 (it replaced
+the old `import.meta.glob` approach). Without it, `Vite::asset()` throws, the callback
+returns `null`, `window.imagewizeIcons` values are empty strings, and every icon renders
+broken in both the editor and the frontend. See `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md`.
+
 ### Adding a new SVG icon
 
 **1. `app/setup.php` — add to both icon_maps:**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.2
+Stable tag: 2.15.3
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,12 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.3 - 07/03/26 =
+* FIXED: Theme icon binding - SVG icons no longer render as broken images in the editor and frontend.
+* TECHNICAL: Added assets: ['resources/images/**'] to Vite laravel() plugin so theme-icon SVGs get manifest entries for Vite::asset() resolution.
+* TECHNICAL: Documented the required vite.config.js assets option in CLAUDE.md, AGENTS.md, and THEME-ICON-BINDING-BROKEN.md; never import SVGs in blocks, use the imagewize/theme-icon binding.
+
 
 = 2.15.2 - 06/30/26 =
 * CHANGED: Removed redundant [session_logging] block from .vibe/config.toml — save_dir was a hardcoded absolute path that crashed Vibe on other machines.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.2
+Version: 2.15.3
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,11 @@ export default defineConfig({
         'resources/css/editor.css',
         'resources/js/editor.js',
       ],
+      // Make static SVG icons (referenced only via Vite::asset() in the
+      // imagewize/theme-icon block binding) part of the build so they get
+      // manifest entries. Without this, Vite::asset() throws and icons render
+      // as broken images. See docs/nynaeve/THEME-ICON-BINDING-BROKEN.md.
+      assets: ['resources/images/**'],
       refresh: true,
     }),
 


### PR DESCRIPTION
This release (version 2.15.3) resolves a critical defect in the `imagewize/theme-icon` block binding that caused SVG icons to render broken in both the editor and the frontend. The root cause was that icon assets in `resources/images/` were never included in the Vite build manifest, so `Vite::asset()` could not resolve their hashed URLs at render time. The fix adds the `assets: ['resources/images/**']` option to the `laravel()` plugin in `vite.config.js`, which emits the icons into the manifest and restores URL resolution — the supported mechanism for `laravel-vite-plugin` v3+ and Vite 8, replacing the older `import.meta.glob` approach. The change is accompanied by documentation updates and a version bump to keep developer guidance and release metadata in sync.

**Build and Asset Pipeline Fix:**
- Added the `assets: ['resources/images/**']` option to the `laravel()` Vite plugin in `vite.config.js` so SVG icons are emitted into the build manifest, allowing `Vite::asset('resources/images/icons/*.svg')` to resolve at render time.
- Without this option, the `imagewize/theme-icon` PHP callback returned `null`, `window.imagewizeIcons` values were empty, and every migrated icon block (`icon-grid`, `feature-cards`, `trust-bar`) rendered broken.

**Documentation and Developer Guidance:**
- Updated `CLAUDE.md` and `AGENTS.md` to document the required Vite `assets` option as a critical step in the theme-icon binding pattern, preventing regressions in future icon work.
- Recorded the fix and its rationale, referencing `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md` for the full failure analysis.

**Release Metadata:**
- Bumped the theme version to 2.15.3 in `style.css`, `readme.txt`, and `CHANGELOG.md` to reflect the fix.

**Files Changed:**

- [`AGENTS.md`](https://github.com/imagewize/nynaeve/blob/v2.15.3/AGENTS.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/v2.15.3/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/nynaeve/blob/v2.15.3/CLAUDE.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/v2.15.3/readme.txt) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/v2.15.3/style.css) (Modified)
- [`vite.config.js`](https://github.com/imagewize/nynaeve/blob/v2.15.3/vite.config.js) (Modified)