### PR TITLE
V2.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.15.4] - 2026-07-06
+
+### Technical - Removed vestigial import.meta.glob call in app.js
+
+**resources/js/app.js:**
+- Removed the leftover `import.meta.glob(['../images/**', '../fonts/**'])` call at the top of the file — it stopped doing anything once Vite 8 started tree-shaking unused glob calls (see 2.15.3 below), and both paths it targeted are already handled elsewhere: images via the `assets` option in `vite.config.js`, fonts via real `url()` references in `resources/css/fonts.css` (imported into `app.css`, so they're part of the actual module graph and were never affected by the tree-shaking issue)
+- No functional change — confirmed via `npm run build` that all font and image manifest entries are unaffected
+
 ## [2.15.3] - 2026-07-03
 
 ### Fixed - Theme icon binding broken by Vite asset hashing

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.3
+Stable tag: 2.15.4
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,9 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.4 - 07/06/26 =
+* TECHNICAL: Removed vestigial import.meta.glob(['../images/**', '../fonts/**']) from resources/js/app.js — dead since Vite 8 tree-shakes unused globs, and both paths are already covered by the assets option (images) and real CSS url() imports (fonts).
 
 = 2.15.3 - 07/03/26 =
 * FIXED: Theme icon binding - SVG icons no longer render as broken images in the editor and frontend.

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,8 +1,3 @@
-import.meta.glob([
-  '../images/**',
-  '../fonts/**',
-]);
-
 // Import our local domReady function with named import
 import { domReady } from './utils/dom-ready';
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.3
+Version: 2.15.4
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
This release removes a vestigial `import.meta.glob(['../images/**', '../fonts/**'])` call from `resources/js/app.js` and bumps the theme to version 2.15.4. The glob call became dead code once Vite 8 began tree-shaking unused glob invocations (as documented in the 2.15.3 release), and both asset paths it previously targeted are already handled through supported mechanisms: images via the `assets` option in `vite.config.js`, and fonts via real `url()` references in `resources/css/fonts.css` that keep them in the module graph. The change is purely a cleanup with no functional impact, verified against the production build output to confirm all font and image manifest entries remain intact. Documentation and version metadata across `CHANGELOG.md`, `readme.txt`, and `style.css` are updated to reflect the 2.15.4 release.

**Code Cleanup:**
- Removed the leftover `import.meta.glob(['../images/**', '../fonts/**'])` call at the top of `resources/js/app.js`, which stopped emitting assets after the Vite 8 tree-shaking behavior introduced in 2.15.3 and duplicated coverage already provided elsewhere in the build pipeline.
- Confirmed via `npm run build` that all font and image manifest entries are unaffected, establishing the removal as a no-op with respect to output assets.

**Version and Documentation Updates:**
- Bumped the theme version from 2.15.3 to 2.15.4 in both `style.css` and the `readme.txt` stable tag to align packaged metadata with the release.
- Added a 2.15.4 entry to `CHANGELOG.md` and `readme.txt` documenting the removal, the rationale tied to the Vite 8 tree-shaking change, and the alternate handling of images (via the `vite.config.js` `assets` option) and fonts (via CSS `url()` imports).

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/v2.15.4/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/v2.15.4/readme.txt) (Modified)
- [`resources/js/app.js`](https://github.com/imagewize/nynaeve/blob/v2.15.4/resources/js/app.js) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/v2.15.4/style.css) (Modified)