### PR TITLE
V2.15.5 - Fix mega menu opening from anywhere along the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.15.5] - 2026-07-23
+
+### Fixed - Services mega menu opened from anywhere along the header
+
+**resources/css/app.css:**
+- Fixed the Services mega menu opening when the pointer was nowhere near "SERVICES" — hovering the bottom edge of the header anywhere across its width (to the right of Contact, beside the Mastodon/GitHub/search icons) triggered the panel
+- Root cause: section 3.4 sets the mega `<li>` to `position: static` so the panel can be full-bleed against the `<nav>`, but the generic dropdown hover bridge in section 3.3 (`#menu .group.relative:has(> ul[role="menu"])::after`, `left: 0; right: 0; top: 100%`) still applied to it. With no positioned ancestor on the li, those insets resolved against the full-width `<nav>`, so the invisible 8px bridge stretched across the entire header instead of sitting under the menu item
+- Section 3.3: added `:not(.mega-menu)` to the generic bridge selector
+- Section 3.4: added a replacement bridge on the mega item's link wrapper (`#menu .my-menu-item.mega-menu > div::after`, with the wrapper made `position: relative`). Negative `left`/`right: -1rem` insets restore the li's `px-4` padding box, so the trigger area is exactly as wide as the visible menu item; `height: 2rem` spans the gap down to the panel
+- Left the panel's own upward `::before` bridge as-is — it is full width, but harmless because `.submenu-list` is `pointer-events: none` while closed, so it only becomes a hover target once the panel is already open
+- Verified with Playwright at 1024/1280/1440/1920: hovering right of Contact at every height in and below the bar leaves the panel closed; Services still opens; the pointer still travels from Services down into the panel without it closing; regular dropdowns (About/Themes/Blog/Contact) are unchanged
+
+**docs/nynaeve/SERVICES-MEGA-MENU.md:**
+- Documented the two halves of the hover bridge and why the generic bridge must exclude the mega item
+
 ## [2.15.4] - 2026-07-06
 
 ### Technical - Removed vestigial import.meta.glob call in app.js

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.4
+Stable tag: 2.15.5
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,9 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.5 - 07/23/26 =
+* FIXED: Services mega menu opened when hovering anywhere along the bottom edge of the header (e.g. to the right of Contact, beside the social icons). The generic dropdown hover bridge now excludes the mega item, which gets its own bridge scoped to the width of the menu item.
 
 = 2.15.4 - 07/06/26 =
 * TECHNICAL: Removed vestigial import.meta.glob(['../images/**', '../fonts/**']) from resources/js/app.js — dead since Vite 8 tree-shakes unused globs, and both paths are already covered by the assets option (images) and real CSS url() imports (fonts).

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -320,7 +320,10 @@ footer a {
 /* Creates an invisible bridge between parent menu item and dropdown menu */
 /* This fills the mt-2 gap so hover state doesn't break when moving to dropdown */
 @media (min-width: 1024px) {
-  #menu .group.relative:has(> ul[role="menu"])::after {
+  /* `:not(.mega-menu)` is required: the mega item is position:static (see 3.4),
+     so this bridge would resolve against the full-width <nav> and turn the whole
+     header strip into a hover target. The mega item gets its own bridge in 3.4. */
+  #menu .group.relative:has(> ul[role="menu"]):not(.mega-menu)::after {
     content: '';
     position: absolute;
     left: 0;
@@ -347,6 +350,26 @@ footer a {
     position: static;
   }
 
+  /* Hover bridge, part 1 (closed -> open). Because the li is static, the generic
+     bridge in 3.3 is disabled for it; this one hangs off the link wrapper so the
+     trigger area stays as wide as the menu item and no wider. The negative
+     insets restore the li's px-4 padding, the height spans the gap down to the
+     panel (li bottom -> nav bottom). */
+  #menu .my-menu-item.mega-menu > div {
+    position: relative;
+  }
+
+  #menu .my-menu-item.mega-menu > div::after {
+    content: '';
+    position: absolute;
+    left: -1rem;
+    right: -1rem;
+    top: 100%;
+    height: 2rem;
+    z-index: 49;
+    display: block;
+  }
+
   /* Full-bleed panel. Reuses .submenu-list reveal (opacity + pointer-events)
      from section 12; here we only re-style the surface and size. */
   .submenu-list.mega-menu-panel {
@@ -361,10 +384,10 @@ footer a {
     box-shadow: 0 24px 50px -12px rgba(0, 0, 0, 0.55);
   }
 
-  /* Hover bridge: the mega-menu li is position:static so the generic
-     .group.relative::after bridge (section 3.3) doesn't cover it.
-     This ::before extends upward from the panel into the gap, keeping
-     .group:hover active while the pointer travels down. */
+  /* Hover bridge, part 2 (stay open). Extends upward from the panel into the
+     gap, keeping .group:hover active while the pointer travels down. Safe to
+     span the full width: the panel is pointer-events:none while closed, so this
+     only becomes a target once the menu is already open. */
   .submenu-list.mega-menu-panel::before {
     content: '';
     position: absolute;

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.4
+Version: 2.15.5
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
**Version:** `2.15.5`

Fixes a hover-target regression in the desktop header where the Services mega menu opened from anywhere along the header width, including far to the right of the Contact item next to the Mastodon, GitHub, and search icons. The root cause was an interaction between two existing rules in `resources/css/app.css`: section 3.4 sets the mega `<li>` to `position: static` so the panel can render full-bleed against the `<nav>`, which leaves the item with no positioned ancestor of its own, so the generic dropdown hover bridge in section 3.3 (`left: 0; right: 0; top: 100%`) resolved its insets against the full-width `<nav>` and stretched an invisible 8px hover target across the entire header. The fix excludes the mega item from the generic bridge and gives it a dedicated replacement anchored to its link wrapper, with negative insets that restore the item's `px-4` padding box so the trigger is exactly as wide as the visible menu item. The panel's own upward bridge is left full-width, which is safe because `.submenu-list` is `pointer-events: none` while closed and therefore only becomes a hover target once the menu is already open. Theme version is bumped to 2.15.5.

**Mega Menu Hover Bridge Fix:**
- Added `:not(.mega-menu)` to the generic dropdown bridge selector (`#menu .group.relative:has(> ul[role="menu"])::after`) in section 3.3, preventing it from applying to the statically positioned mega item.
- Introduced a scoped replacement bridge in section 3.4 on `#menu .my-menu-item.mega-menu > div::after`, with the wrapper set to `position: relative`, `left`/`right: -1rem` to restore the li's horizontal padding, and `height: 2rem` to span the gap down to the panel.
- Retained the panel's upward `::before` bridge unchanged, since it only becomes interactive after the panel opens; regular dropdowns (About, Themes, Blog, Contact) are unaffected by either change.

**Verification:**
- Validated with Playwright at 1024, 1280, 1440, and 1920 viewport widths: hovering to the right of Contact at every height within and below the header bar leaves the panel closed, Services still opens on hover, and the pointer can still travel from Services into the panel without it closing.

**Release Metadata and Documentation:**
- Bumped the theme version from 2.15.4 to 2.15.5 in `style.css` and `readme.txt`.
- Added a `[2.15.5]` entry to `CHANGELOG.md` documenting the root cause, both halves of the hover bridge, and the verification matrix.

Note: the changelog entry references documentation updates to `docs/nynaeve/SERVICES-MEGA-MENU.md`, but that file is not among the changed files in this branch — the doc change should either be included or the changelog line dropped.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/v2.15.5/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/v2.15.5/readme.txt) (Modified)
- [`resources/css/app.css`](https://github.com/imagewize/nynaeve/blob/v2.15.5/resources/css/app.css) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/v2.15.5/style.css) (Modified)