### PR TITLE
Bump to 2.15.6 (guzzle security update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.15.6] - 2026-07-23
+
+### Security - Updated guzzlehttp/guzzle to 7.15.1
+
+**composer.lock:**
+- Upgraded `guzzlehttp/guzzle` 7.13.1 → 7.15.1, `guzzlehttp/promises` 2.5.0 → 2.5.1, `guzzlehttp/psr7` 2.12.3 → 2.13.0
+- Resolves all four open Dependabot alerts on the theme repository, every one of them against guzzle: GHSA-h95v-h523-3mw8, GHSA-f283-ghqc-fg79, GHSA-wm3w-8rrp-j577 (all patched in 7.15.1) and GHSA-94pj-82f3-465w (patched in 7.14.2)
+- Guzzle is a transitive dependency — required by `roots/acorn` (^7.8) and `illuminate/http` (^7.8.2), never listed directly in `composer.json`. Updated with `composer update guzzlehttp/guzzle --with-all-dependencies`, so `composer.json` is unchanged and the existing constraints already permit 7.15.1
+- `composer audit` reports no remaining advisories
+
 ## [2.15.5] - 2026-07-23
 
 ### Fixed - Services mega menu opened from anywhere along the header

--- a/composer.lock
+++ b/composer.lock
@@ -770,22 +770,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.1",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.3",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -797,8 +797,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.6",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -878,7 +878,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -894,20 +894,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-29T20:14:18+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -962,7 +962,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -978,20 +978,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.3",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -1081,7 +1081,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1097,7 +1097,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:21:08+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.5
+Stable tag: 2.15.6
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,9 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.6 - 07/23/26 =
+* SECURITY: Updated guzzlehttp/guzzle from 7.13.1 to 7.15.1, resolving four Dependabot advisories (GHSA-h95v-h523-3mw8, GHSA-f283-ghqc-fg79, GHSA-wm3w-8rrp-j577, GHSA-94pj-82f3-465w). Transitive dependency via roots/acorn and illuminate/http — composer.lock only, no composer.json change.
 
 = 2.15.5 - 07/23/26 =
 * FIXED: Services mega menu opened when hovering anywhere along the bottom edge of the header (e.g. to the right of Contact, beside the social icons). The generic dropdown hover bridge now excludes the mega item, which gets its own bridge scoped to the width of the menu item.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.5
+Version: 2.15.6
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
**Version:** `2.15.6`

Security maintenance release bumping the Nynaeve theme to 2.15.6, upgrading `guzzlehttp/guzzle` from 7.13.1 to 7.15.1 along with its companion packages `guzzlehttp/promises` (2.5.0 → 2.5.1) and `guzzlehttp/psr7` (2.12.3 → 2.13.0). This resolves all four open Dependabot advisories on the theme repository — GHSA-h95v-h523-3mw8, GHSA-f283-ghqc-fg79 and GHSA-wm3w-8rrp-j577 (patched in 7.15.1), plus GHSA-94pj-82f3-465w (patched in 7.14.2). Guzzle is a transitive dependency pulled in by `roots/acorn` (^7.8) and `illuminate/http` (^7.8.2) and is never declared directly, so the update was applied with `composer update guzzlehttp/guzzle --with-all-dependencies` and touches `composer.lock` only; the existing constraints already permitted 7.15.1, leaving `composer.json` unchanged. No theme code, block, or template files are modified, so runtime behavior is unaffected and `composer audit` now reports no remaining advisories.

**Dependency Security Update:**
- Upgraded `guzzlehttp/guzzle` 7.13.1 → 7.15.1 to close four outstanding CVE advisories flagged by Dependabot, three of which required 7.15.1 and one 7.14.2.
- Pulled in the matching `guzzlehttp/promises` 2.5.1 and `guzzlehttp/psr7` 2.13.0 releases via `--with-all-dependencies` to keep the Guzzle package set consistent.
- Constrained to `composer.lock` because Guzzle is transitive through `roots/acorn` and `illuminate/http`; no direct requirement was added to `composer.json`, avoiding an unnecessary top-level dependency.

**Version and Release Metadata:**
- Bumped the theme version to 2.15.6 in `style.css` and the `Stable tag` in `readme.txt` to keep WordPress theme headers in sync with the release.
- Added a `[2.15.6] - 2026-07-23` Security entry to `CHANGELOG.md` documenting the affected packages, each advisory identifier, and the rationale for the lock-file-only change.
- Mirrored the release note in the `readme.txt` changelog section for consistency with the theme's existing release documentation format.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/v2.15.6/CHANGELOG.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/v2.15.6/readme.txt) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/v2.15.6/style.css) (Modified)

*Dependency lock files updated:* composer.lock,