### PR TITLE
Bump to 2.15.7 (npm security updates)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - Playwright: `npm run pw` or scoped (e.g., `npm run pw:mobile`).
 
 ## Commit & Pull Request Guidelines
+- Branch names must NEVER match a release tag. Releases are tagged `vX.Y.Z`, so a branch named `v2.15.7` collides with the `v2.15.7` tag and makes every ref ambiguous (`git checkout`/`log`/`push v2.15.7` resolves unpredictably). Use `release/2.15.7` or a descriptive name (`npm-security-updates`) instead. Existing `v2.15.x` branches predate this rule — don't copy them.
 - Commits: short Title-Case (e.g., `Nynaeve Documentation Update`); scope narrowly.
 - PRs: include purpose, affected theme paths, manual test commands, linked issues/trellis tickets; add screenshots/GIFs for UI/block changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Nynaeve theme will be documented in this file.
 
 For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
 
+## [2.15.7] - 2026-07-25
+
+### Technical - npm dependency security updates
+
+**Dependency Updates (dev dependencies):**
+- Updated `nanoid` from 3.3.12 to 3.3.16 to address reported security advisories
+- Updated `postcss` from 8.5.15 to 8.5.23, which pulls in the patched `nanoid` (`^3.3.16`)
+- Updated `fast-uri` from 3.1.2 to 3.1.4
+
+**Notes:**
+- Changes are limited to `package-lock.json`; no direct dependency versions in `package.json` were changed
+- All updated packages are build-time only (`dev` dependencies) and are not shipped in the compiled theme output
+- No user-facing markup, styling, or behavior changes in this release
+
 ## [2.15.6] - 2026-07-23
 
 ### Security - Updated guzzlehttp/guzzle to 7.15.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code when working with the Nynaeve theme.
 7. [Architecture](#architecture)
 8. [Code Standards](#code-standards)
 9. [Common Tasks](#common-tasks)
+10. [Git & Release Workflow](#git--release-workflow)
 
 ---
 
@@ -397,3 +398,22 @@ Quote-based (no cart/checkout). Custom templates in `resources/views/woocommerce
 ```
 
 `app.css` controls all product page colors. Hardcoded color classes override CSS and break the design system.
+
+---
+
+## Git & Release Workflow
+
+### Branch Names Must Never Match a Release Tag (CRITICAL)
+
+Releases are tagged `vX.Y.Z` (e.g. `v2.15.7`). **Never name a branch after the version it releases** — Git then has a branch and a tag with the identical name, and every ambiguous ref (`git checkout v2.15.7`, `git log v2.15.7`, `git push origin v2.15.7`) resolves unpredictably and prints `warning: refname 'v2.15.7' is ambiguous`.
+
+```bash
+# ❌ WRONG — collides with the v2.15.7 tag created at release time
+git checkout -b v2.15.7
+
+# ✅ CORRECT — use a release/ prefix (or a descriptive name)
+git checkout -b release/2.15.7
+git checkout -b npm-security-updates
+```
+
+Older branches (`v2.15.2`, `v2.15.3`, `v2.15.5`, `v2.15.6`) predate this rule and already collide with their tags. Do not follow them as a pattern.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,9 +1460,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -1953,9 +1953,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2054,9 +2054,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2074,7 +2074,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.6
+Stable tag: 2.15.7
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,12 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.7 - 07/25/26 =
+* TECHNICAL: npm security updates - Updated nanoid (3.3.12 to 3.3.16) and postcss (8.5.15 to 8.5.23) to address reported advisories.
+* TECHNICAL: Dependency bump - Updated fast-uri from 3.1.2 to 3.1.4.
+* TECHNICAL: Lockfile only - All updates are build-time dev dependencies; no frontend or theme behavior changes.
+
 
 = 2.15.6 - 07/23/26 =
 * SECURITY: Updated guzzlehttp/guzzle from 7.13.1 to 7.15.1, resolving four Dependabot advisories (GHSA-h95v-h523-3mw8, GHSA-f283-ghqc-fg79, GHSA-wm3w-8rrp-j577, GHSA-94pj-82f3-465w). Transitive dependency via roots/acorn and illuminate/http — composer.lock only, no composer.json change.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.6
+Version: 2.15.7
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
**Version:** `2.15.7`

## Summary

This pull request introduces changes from the `release/2.15.7` branch into `main`. The changes include 3 commit(s) affecting 6 modified file(s).

## Changes

 6 files changed, 53 insertions(+), 12 deletions(-)

**Commits:**

- Document branch naming rule to avoid release tag collisions (c408662)
- Bump theme version to 2.15.7 (450f126)
- Update npm dev dependencies (nanoid, postcss, fast-uri) (7715356)

**Files Changed:**

- [`AGENTS.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.7/AGENTS.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.7/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.7/CLAUDE.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/release/2.15.7/readme.txt) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/release/2.15.7/style.css) (Modified)

*Dependency lock files updated:* package-lock.json,