### PR TITLE
Nynaeve 2.15.8 - Self-Contained Documentation and Git Workflow Rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `app/`: PHP (Blocks, Providers, View Composers); `config/`: Sage/Acorn config.
 - `resources/`: Tailwind (`css/`), JS (`js/`), Blade views (`views/`), native blocks (`js/blocks/`); block styles live with each block.
 - Built assets in `public/build/` (Vite); static assets in `resources/images/`.
-- Utilities in `scripts/`; theme docs in `docs/`; `archive/` is deprecated/read-only.
+- Utilities in `scripts/`; `archive/` is deprecated/read-only. Theme guidance lives in `CLAUDE.md` (self-contained — no external docs folder ships with the theme).
 
 ## Build, Test, and Development Commands
 - Install deps: `cd site && composer install`; then `cd site/web/app/themes/nynaeve && composer install && npm install`.
@@ -18,10 +18,10 @@
 - PHP: PSR-4 under `App\\`, prefer strict types; format with Pint.
 - JS/React: ES modules, functional components; block dirs kebab-case (`cta-block-blue`), components PascalCase.
 - Blocks: InnerBlocks-first; use real content (no placeholders); no horizontal padding (theme handles spacing); keep styling on containers, not core child blocks.
-- `block.json`: namespace/category/textdomain `imagewize`; default align `wide`; button styles via `core/buttons` container class (not individual buttons); add `"example": {}` for an inserter preview.
+- `block.json`: three prefixes, don't mix them — namespace `imagewize` (`"name": "imagewize/my-block"`), category `nynaeve` (`"category": "nynaeve/content"` — slugs registered in `app/setup.php`; an unregistered slug drops the block into the generic category), textdomain `nynaeve` (the theme Text Domain, NOT `imagewize` or `sage`); default align `wide`; button styles via `core/buttons` container class (not individual buttons); add `"example": {}` for an inserter preview.
 - Full-width (`alignfull`) blocks: set a default margin reset in `block.json` attributes (`"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}`) — NOT a CSS override — so the constrained-layout `margin-block-start` gap is removed while users keep spacing control. Applies only to newly inserted blocks; existing ones must be updated manually.
 - Blade views in `resources/views`; reuse via `partials/` and `sections/`. CSS is Tailwind-first, custom in `resources/css` or block `style.css`.
-- SVG icons in blocks: never `import` SVGs (Vite hashes them → stale URLs). Use the `imagewize/theme-icon` binding + `window.imagewizeIcons` (both from `app/setup.php`). `vite.config.js` MUST keep `assets: ['resources/images/**']` on the `laravel()` plugin so `Vite::asset()` can resolve the icons — without it every icon renders broken in editor and frontend. See CLAUDE.md "SVG Icons in Block Templates" and `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md`.
+- SVG icons in blocks: never `import` SVGs (Vite hashes them → stale URLs). Use the `imagewize/theme-icon` binding + `window.imagewizeIcons` (both from `app/setup.php`). `vite.config.js` MUST keep `assets: ['resources/images/**']` on the `laravel()` plugin so `Vite::asset()` can resolve the icons — without it every icon renders broken in editor and frontend. See CLAUDE.md "SVG Icons in Block Templates".
 
 ### WooCommerce Customization
 - Quote-based system (no cart/checkout); custom templates in `resources/views/woocommerce/`; "Request Quote" buttons replace add-to-cart.
@@ -38,6 +38,9 @@
 - Playwright: `npm run pw` or scoped (e.g., `npm run pw:mobile`).
 
 ## Commit & Pull Request Guidelines
+- **Branch per change**: never commit theme work directly to `main`. Every update (feature, fix, docs, dep bump) branches off `main` and lands via PR — `release-theme.sh` diffs the branch against `main`, so direct-to-`main` work yields an empty release changelog.
+- **Atomic commits**: stage files individually or in small logical groups (`git add` per file/group) and commit each with a specific message — never stage unrelated files together (e.g. commit documentation separately from block code).
+- **No AI attribution**: no `🤖 Generated with Claude Code` or `Co-Authored-By:` footers — keep history attribution-free.
 - Branch names must NEVER match a release tag. Releases are tagged `vX.Y.Z`, so a branch named `v2.15.7` collides with the `v2.15.7` tag and makes every ref ambiguous (`git checkout`/`log`/`push v2.15.7` resolves unpredictably). Use `release/2.15.7` or a descriptive name (`npm-security-updates`) instead. Existing `v2.15.x` branches predate this rule — don't copy them.
 - Commits: short Title-Case (e.g., `Nynaeve Documentation Update`); scope narrowly.
 - PRs: include purpose, affected theme paths, manual test commands, linked issues/trellis tickets; add screenshots/GIFs for UI/block changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,32 @@
 
 All notable changes to the Nynaeve theme will be documented in this file.
 
-For project-wide changes (infrastructure, tooling, cross-cutting concerns), see the [project root CHANGELOG.md](../../../../../CHANGELOG.md).
+## [2.15.8] - 2026-07-25
+
+### Documentation - Self-contained agent guidance and Git workflow rules
+
+**CLAUDE.md:**
+- Fixed four broken relative links (`docs/ACF-BLOCKS.md`, `docs/BLOCKS.md`, `docs/CONTENT-WIDTH-AND-LAYOUT.md`, `docs/PATTERN-TO-NATIVE-BLOCK.md`) — they pointed at a `docs/` folder that does not exist inside the theme
+- Inlined the load-bearing essentials from those docs (layout/padding system, ACF field defaults) so the theme's guidance is self-contained for anyone using the theme outside the imagewize.com monorepo
+- Added "Branch Per Change" — never commit theme work directly to `main`; `release-theme.sh` diffs the current branch against `main`, so direct-to-`main` work produces an empty release changelog
+- Added "Atomic Commits" — stage files individually or in small logical groups, one logical change per commit, no AI attribution footers
+
+**AGENTS.md:**
+- Added matching branch-per-change, atomic-commit, and no-attribution rules
+- Removed stale reference to a theme-level `docs/` folder
+
+**block.json prefix corrections (CLAUDE.md + AGENTS.md):**
+- Documented the three distinct prefixes that were previously conflated: namespace `imagewize` (`"name": "imagewize/my-block"`), category `nynaeve` (`"category": "nynaeve/content"`), textdomain `nynaeve`
+- Fixed the documented category prefix, which incorrectly read `imagewize/*` — categories are registered as `nynaeve/*` in `app/setup.php` (`block_categories_all`), and an unregistered slug silently drops a block into the editor's generic category
+- Corrected the example `block.json` accordingly
+
+**CHANGELOG.md:**
+- Removed the intro link to the project root `CHANGELOG.md` (`../../../../../CHANGELOG.md`) — it escapes the theme directory and is unreachable outside the imagewize.com monorepo
+- De-linked `docs/DEV.md`, `docs/BLOCKS.md`, and `docs/WOOCOMMERCE.md` in the historical 1.20.2 entry (now plain code spans) — same missing theme-level `docs/` folder; the historical record is unchanged
+- Every link in the theme's markdown now resolves within the theme itself
+
+**Notes:**
+- Documentation only; no PHP, block, markup, styling, or build output changes
 
 ## [2.15.7] - 2026-07-25
 
@@ -1790,9 +1815,9 @@ For project-wide changes (infrastructure, tooling, cross-cutting concerns), see 
 ### Changed
 - **Documentation Restructure**: Reorganized README.md and created dedicated documentation files
   - README.md now concise and user-focused (~90 lines, down from 330+)
-  - Created [docs/DEV.md](docs/DEV.md) - Complete developer guide with commands, architecture, and workflows
-  - Created [docs/BLOCKS.md](docs/BLOCKS.md) - Comprehensive block library with usage examples for all 10 custom blocks
-  - Created [docs/WOOCOMMERCE.md](docs/WOOCOMMERCE.md) - WooCommerce integration guide covering Quote/Standard/Catalog modes
+  - Created `docs/DEV.md` - Complete developer guide with commands, architecture, and workflows
+  - Created `docs/BLOCKS.md` - Comprehensive block library with usage examples for all 10 custom blocks
+  - Created `docs/WOOCOMMERCE.md` - WooCommerce integration guide covering Quote/Standard/Catalog modes
   - Documentation structure inspired by Ollie theme for improved discoverability and user experience
   - All detailed technical information preserved in well-organized, dedicated documentation files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code when working with the Nynaeve theme.
 7. [Architecture](#architecture)
 8. [Code Standards](#code-standards)
 9. [Common Tasks](#common-tasks)
-10. [Git & Release Workflow](#git--release-workflow)
+10. [Git & Release Workflow](#git--release-workflow) — branch per change, atomic commits
 
 ---
 
@@ -49,7 +49,7 @@ composer pint      # PHP code quality (Laravel Pint)
 
 **1. InnerBlocks (MOST PREFERRED)** — content blocks, full typography control, user-selectable styles
 **2. Sage Native Blocks with Custom Controls** — dynamic JS interactivity, complex data structures
-**3. ACF Composer Blocks** — repeater fields, server-side rendering, rigid brand control. See [docs/ACF-BLOCKS.md](docs/ACF-BLOCKS.md)
+**3. ACF Composer Blocks** — repeater fields, server-side rendering, rigid brand control
 
 ### InnerBlocks Best Practices
 
@@ -117,7 +117,17 @@ WordPress **does not reliably apply className to button links** in InnerBlocks t
 .wp-block-imagewize-my-block { padding: 5rem 1.25rem; }
 ```
 
-See [docs/CONTENT-WIDTH-AND-LAYOUT.md](docs/CONTENT-WIDTH-AND-LAYOUT.md) for full details.
+**Why:** `theme.json` (`contentSize: 55rem`, `wideSize: 64rem`, `useRootPaddingAwareAlignments: true`) plus one zero-specificity rule in `app.css` already pads everything unaligned — so editor-set padding still wins:
+```css
+:where(.is-layout-constrained) > :not(.alignfull):not(.alignwide) {
+  padding-left: var(--wp--preset--spacing--50);
+  padding-right: var(--wp--preset--spacing--50);
+}
+```
+
+Two consequences:
+- **Block nests a `core/group`?** Its `.wp-block-group__inner-container` gets core padding too → double padding. Add it to the reset list in `app.css` (currently `imagewize-about`, `imagewize-pricing`).
+- **Full-width background?** Pad the *inner* wrapper (e.g. `.page-heading-blue__content`), never the outer block — background goes edge-to-edge, content stays inset.
 
 ### `.wp-block-paragraph` Does Not Exist on the Frontend (CRITICAL)
 
@@ -168,7 +178,7 @@ trellis vm shell --workdir /srv/www/imagewize.com/current/web/app/themes/nynaeve
 # Creates: app/Blocks/MyBlock.php + resources/views/blocks/my-block.blade.php
 ```
 
-See [docs/ACF-BLOCKS.md](docs/ACF-BLOCKS.md).
+Define fields in the controller's `fields()`; give every field a **default value** so the block renders real content the moment it's inserted (an empty ACF block looks broken in the inserter preview). Run `wp acorn acf:clear` after changing field definitions.
 
 ## SVG Icons in Block Templates (Block Bindings Pattern)
 
@@ -194,7 +204,7 @@ laravel({
 This is the supported mechanism for `laravel-vite-plugin` v3+ / Vite 8 (it replaced
 the old `import.meta.glob` approach). Without it, `Vite::asset()` throws, the callback
 returns `null`, `window.imagewizeIcons` values are empty strings, and every icon renders
-broken in both the editor and the frontend. See `docs/nynaeve/THEME-ICON-BINDING-BROKEN.md`.
+broken in both the editor and the frontend.
 
 ### Adding a new SVG icon
 
@@ -235,9 +245,10 @@ Older WordPress emitted `style="width:Xpx;height:Xpx"` from `width`/`height` att
 
 ## Block Standards
 
-**block.json checklist:**
-- `"category": "imagewize/*"` (semantic subcategories: hero, features, cta, testimonials, pricing, content, media, portfolio)
-- `"textdomain": "nynaeve"` (the theme's Text Domain — NOT "sage" or "imagewize")
+**block.json checklist — three different prefixes, don't mix them up:**
+- `"name": "imagewize/my-block"` — the block **namespace** is `imagewize` (brand-level; 24 of 27 blocks use it)
+- `"category": "nynaeve/*"` — the **category** prefix is `nynaeve`, registered in `app/setup.php` via `block_categories_all`. Slugs: `nynaeve/hero`, `nynaeve/features`, `nynaeve/cta`, `nynaeve/testimonials`, `nynaeve/pricing`, `nynaeve/content`, `nynaeve/media`, `nynaeve/portfolio`. An unregistered slug (e.g. `imagewize/content`) silently drops the block into the editor's generic category
+- `"textdomain": "nynaeve"` — the theme's Text Domain from `style.css`, NOT "sage" or "imagewize"
 - `"example": {}` — enables inserter hover preview
 - `"align": "wide"` default — centers at contentSize (880px), user can change
 - `"color": { "background": true, "text": true }` for section-level blocks
@@ -264,7 +275,7 @@ This renders as `style="margin-top:0;margin-bottom:0"` inline — users can stil
   "apiVersion": 3,
   "name": "imagewize/my-block",
   "title": "My Block",
-  "category": "imagewize/content",
+  "category": "nynaeve/content",
   "icon": "grid-view",
   "description": "Block description",
   "keywords": ["keyword1"],
@@ -363,15 +374,11 @@ nynaeve/
 - `imagewize/trust-bar` — Trust signal bar with 4 icon+text items
 - `imagewize/two-column-card` — Professional card grid
 
-See [docs/BLOCKS.md](docs/BLOCKS.md).
-
 ### Adding New Custom Block
 
 1. Run `wp acorn sage-native-block:create` in Trellis VM
 2. Develop in `resources/js/blocks/my-block/` — InnerBlocks, real content, no hardcoded style classes
 3. Block auto-registers; test in editor
-
-See [docs/PATTERN-TO-NATIVE-BLOCK.md](docs/PATTERN-TO-NATIVE-BLOCK.md).
 
 ### Page Template Layout Convention
 
@@ -402,6 +409,37 @@ Quote-based (no cart/checkout). Custom templates in `resources/views/woocommerce
 ---
 
 ## Git & Release Workflow
+
+### Branch Per Change (CRITICAL)
+
+**Never commit theme work directly to `main`.** Every update — feature, fix, docs, dependency bump — starts on its own branch off `main`, and lands via PR.
+
+```bash
+git checkout main && git pull
+git checkout -b fix/service-hero-mobile-padding
+```
+
+`release-theme.sh` diffs the current branch against `main` to generate the changelog, so work committed straight to `main` produces an empty release changelog.
+
+### Atomic Commits (CRITICAL)
+
+Stage files individually or in small logical groups and commit each with its own specific message. **Never stage unrelated files together** — e.g. commit documentation separately from block code, and a dependency bump separately from the fix that motivated it.
+
+```bash
+# ❌ WRONG — one commit mixing block code, docs, and a version bump
+git add -A && git commit -m "Updates"
+
+# ✅ CORRECT — one logical change per commit
+git add resources/js/blocks/service-hero/style.css
+git commit -m "Service Hero Mobile Padding Fix"
+
+git add CLAUDE.md AGENTS.md
+git commit -m "Nynaeve Documentation Update"
+```
+
+**Commit messages:** short Title-Case (e.g. `Nynaeve Documentation Update`, `Hero Pattern Grid Fix`), scoped narrowly.
+
+**No AI attribution** in any commit — no `🤖 Generated with Claude Code`, no `Co-Authored-By: Claude` footers. Keep history attribution-free.
 
 ### Branch Names Must Never Match a Release Tag (CRITICAL)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.7
+Stable tag: 2.15.8
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,14 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 2.15.8 - 07/25/26 =
+* DOCUMENTATION: Fixed four broken relative doc links in CLAUDE.md that pointed at a `docs/` folder not present in the theme.
+* DOCUMENTATION: Inlined the essential layout/padding and ACF block guidance so theme guidance is self-contained.
+* DOCUMENTATION: Added branch-per-change and atomic-commit rules to CLAUDE.md and AGENTS.md.
+* DOCUMENTATION: Corrected block.json guidance - namespace is `imagewize`, but category (`nynaeve/content`) and textdomain (`nynaeve`) both use the `nynaeve` prefix. The documented category prefix was wrong and would place new blocks in an unregistered editor category.
+* DOCUMENTATION: Removed unreachable links from CHANGELOG.md - the project root changelog link and three `docs/` links that escaped the theme directory. Every link in the theme's markdown now resolves within the theme.
+* TECHNICAL: Documentation only; no theme behavior, markup, or build output changes.
 
 = 2.15.7 - 07/25/26 =
 * TECHNICAL: npm security updates - Updated nanoid (3.3.12 to 3.3.16) and postcss (8.5.15 to 8.5.23) to address reported advisories.

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.7
+Version: 2.15.8
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
**Version:** `2.15.8`

This release is documentation-only, correcting agent-facing guidance in `CLAUDE.md` and `AGENTS.md` and bumping the theme to 2.15.8. The primary fix is a corrected `block.json` prefix table: the documented block category prefix incorrectly read `imagewize/*`, while categories are actually registered as `nynaeve/*` in `app/setup.php` via `block_categories_all`, meaning any block created from the old guidance would silently land in the editor's generic category. The change also resolves every broken relative link in the theme's markdown — four `docs/` links in `CLAUDE.md`, a project root `CHANGELOG.md` link that escaped the theme directory with `../../../../../`, and three historical `docs/` links in the 1.20.2 entry — and inlines the load-bearing content from those missing files so the theme's guidance stands alone outside the imagewize.com monorepo. Finally, it codifies the branch-per-change and atomic-commit workflow rules in both agent guidance files. No PHP, block, markup, styling, or build output changed across the five modified files (96 insertions, 22 deletions).

**Block Standards Corrections:**
- Fixed the documented block category prefix from `imagewize/*` to `nynaeve/*`, matching the slugs actually registered in `app/setup.php` (`nynaeve/hero`, `nynaeve/features`, `nynaeve/cta`, `nynaeve/content`, and others); an unregistered slug fails silently rather than erroring, so the incorrect documentation produced miscategorized blocks with no visible warning.
- Documented the three distinct prefixes that were previously conflated in one place: namespace `imagewize` (`"name": "imagewize/my-block"`), category `nynaeve`, and textdomain `nynaeve` (the theme's Text Domain from `style.css`, not `sage` or `imagewize`).
- Updated the reference `block.json` example in both `CLAUDE.md` and `AGENTS.md` so copy-paste use produces a correctly registered block.

**Documentation Portability:**
- Removed four broken relative links in `CLAUDE.md` pointing at a theme-level `docs/` folder that does not exist (`ACF-BLOCKS.md`, `BLOCKS.md`, `CONTENT-WIDTH-AND-LAYOUT.md`, `PATTERN-TO-NATIVE-BLOCK.md`).
- Inlined the essential content from those documents — the layout and block padding system, and the ACF field default-value requirement — so guidance is self-contained for anyone using the theme outside the monorepo.
- Removed the `CHANGELOG.md` intro link to the project root changelog and de-linked three `docs/` references in the historical 1.20.2 entry to plain code spans, preserving the historical record while ensuring every link in the theme's markdown resolves within the theme.

**Git Workflow Rules:**
- Added a "Branch Per Change" section requiring all theme work to start on its own branch off `main` and land via PR, because `release-theme.sh` generates its changelog by diffing the current branch against `main` — work committed directly to `main` yields an empty release changelog.
- Added an "Atomic Commits" section requiring files to be staged individually or in small logical groups, with one logical change per commit and no AI attribution footers in history.

**Version Release:**
- Bumped theme version to 2.15.8 in `style.css` and the `Stable tag` in `readme.txt`, with matching entries added to `CHANGELOG.md` and the `readme.txt` changelog.

**Files Changed:**

- [`AGENTS.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.8/AGENTS.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.8/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/nynaeve/blob/release/2.15.8/CLAUDE.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/release/2.15.8/readme.txt) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/release/2.15.8/style.css) (Modified)