### PR TITLE
Add Packagist Badges To README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Nynaeve theme will be documented in this file.
 
+## [2.15.10] - 2026-08-11
+
+### Documentation - Packagist badges
+
+**README.md:**
+- Added Packagist badges (Total Downloads, Latest Stable Version, License) linking to `packagist.org/packages/imagewize/nynaeve`, alongside the existing Composer installation documentation
+
 ## [2.15.9] - 2026-08-10
 
 ### Security - Dependency updates

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
   # Nynaeve
 </div>
 <div align="center">
+
+[![Total Downloads](https://img.shields.io/packagist/dt/imagewize/nynaeve.svg)](https://packagist.org/packages/imagewize/nynaeve)
+[![Latest Stable Version](https://img.shields.io/packagist/v/imagewize/nynaeve.svg)](https://packagist.org/packages/imagewize/nynaeve)
+[![License](https://img.shields.io/packagist/l/imagewize/nynaeve.svg)](https://packagist.org/packages/imagewize/nynaeve)
+
+</div>
+<div align="center">
 Design better, build faster, deliver results. Nynaeve is a modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
 </div>
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 2.15.9
+Version: 2.15.10
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
Adds Total Downloads, Latest Stable Version, and License badges to the README, matching the style used in sage-native-block/README.md, linked to the imagewize/nynaeve Packagist package.

Bumps theme version to 2.15.10 and updates CHANGELOG.md accordingly.