### PR TITLE
Nynaeve 3.0.1 — README block inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the Nynaeve theme will be documented in this file.
 
+## [3.0.1] - 2026-08-15
+
+### Documentation - README block inventory brought up to date with 3.0.0
+
+**README.md:**
+- Block count corrected from 27 to 35 — the eight blocks added in 3.0.0 (seven `cta-*` service blocks and `quick-summary`) shipped without a README entry
+- Added a **Service CTAs** section documenting `imagewize/cta-seo-service`, `imagewize/cta-fse-block-theme`, `imagewize/cta-performance-partnership`, `imagewize/cta-sage-agency`, `imagewize/cta-trellis-hosting`, `imagewize/cta-woocommerce`, and `imagewize/cta-wordpress-development`, grouped separately from the existing general-purpose CTA blocks
+- Added **Quick Summary** under Content & Layout
+
+**Notes:**
+- Documentation only; no PHP, block, markup, styling, or build output changes
+- The 35 count matches the block registry (`resources/js/blocks/`), which includes `imagewize/slide` — the carousel's child block, not listed individually since it is never inserted on its own
+
 ## [3.0.0] - 2026-08-15
 
 ### BREAKING - All blocks consolidated under the `imagewize` namespace

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Design better, build faster, deliver results. Nynaeve is a modern WordPress them
 
 ## Features
 
-- **27 Professional Custom Blocks** - CTAs, hero banners, content layouts, pricing tables, carousels, reviews, portfolio grids, and more
+- **35 Professional Custom Blocks** - CTAs, hero banners, content layouts, pricing tables, carousels, reviews, portfolio grids, and more
 - **InnerBlocks Architecture** - Built with native WordPress blocks for maximum flexibility
 - **Modern Build Tools** - Vite with HMR, Tailwind CSS 4, Laravel Blade templates
 - **WooCommerce Ready** - Quote mode, catalog mode, or standard e-commerce
@@ -52,12 +52,25 @@ The theme includes these professionally-designed blocks (all using InnerBlocks f
 - **Service Intro** - Introductory text section for service pages with white background and constrained width
 - **Service Detail Cards** - Stacked service cards with numbered heading, description, and checklist
 - **Related Links** - Responsive auto-fit grid of linked pills with arrow icons for related services sections
+- **Quick Summary** - Highlighted summary callout for the top of a long-form post, with tertiary background and green left border
 
 **Call-to-Actions**
 - **CTA Block Blue** - Blue call-to-action section with centered content and button
 - **CTA Columns** - Multi-column CTA cards with customizable styling
 - **Contact Section** - Dark contact section with info column and Contact Form 7 form card
 - **Page Heading Blue** - Blue page header with centered heading
+
+**Service CTAs**
+
+Seven ready-to-drop-in call-to-action blocks, one per service, each with heading, description, bullet list, and dual action buttons on a tertiary background with a green left border:
+
+- **CTA: SEO Service** - SEO service call-to-action
+- **CTA: FSE Block Theme** - FSE / block theme development call-to-action
+- **CTA: Performance Partnership** - Speed optimization partnership call-to-action
+- **CTA: Sage Agency Development** - Sage and agency development partnership call-to-action
+- **CTA: Trellis Hosting** - Trellis managed WordPress hosting call-to-action
+- **CTA: WooCommerce** - WooCommerce development call-to-action
+- **CTA: WordPress Development** - General WordPress development call-to-action
 
 **Social Proof**
 - **Review Profiles** - Customer reviews with circular profile images (3-column layout)

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 3.0.0
+Version: 3.0.1
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
## Summary

Mirror sync of [imagewize/imagewize.com#392](https://github.com/imagewize/imagewize.com/pull/392). The eight blocks added in 3.0.0 (seven `cta-*` service blocks and `quick-summary`) shipped without a README entry; this brings the inventory back in line with `resources/js/blocks/` and cuts a 3.0.1 docs release.

## Changes

**README.md**
- Block count 27 → 35
- New **Service CTAs** section: `cta-seo-service`, `cta-fse-block-theme`, `cta-performance-partnership`, `cta-sage-agency`, `cta-trellis-hosting`, `cta-woocommerce`, `cta-wordpress-development`
- **Quick Summary** added under Content & Layout

**CHANGELOG.md** — 3.0.1 entry
**style.css** — `Version: 3.0.0` → `3.0.1`

## Notes

- Documentation only; no PHP, block, markup, styling, or build output changes
- Synced from imagewize.com via `rsync-theme.sh`; these three files were the only content differences, so the mirror was already current with 3.0.0
- Deployed to production ahead of this sync — `main@8db6f31`, release `20260815031538`, theme reporting 3.0.1 active