### PR TITLE
Nynaeve 3.1.0 — Two-Column Blog Post Layout With Sticky Sidebar CTA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,13 @@
 - Commits: short Title-Case (e.g., `Nynaeve Documentation Update`); scope narrowly.
 - PRs: include purpose, affected theme paths, manual test commands, linked issues/trellis tickets; add screenshots/GIFs for UI/block changes.
 
+## Releases & Version Bumps
+- A version bump touches **four** places, all together: `style.css` `Version:`; `readme.txt` `Stable tag:`; a new `= X.Y.Z - MM/DD/YY =` block atop `== Changelog ==` in `readme.txt` (concise, WP.org style, lines prefixed `FEATURE:`/`FIXED:`/`SECURITY:`/`TECHNICAL:`/`DOCUMENTATION:`/`BREAKING:`); and a new `## [X.Y.Z] - YYYY-MM-DD` section atop `CHANGELOG.md` (detailed Keep-a-Changelog style, naming files touched). Note the two changelogs use different date formats and different levels of detail.
+- Prefer the script over hand-editing — it does all four and generates both formats from the branch diff. Run it **from the repo root**, not the theme dir: `~/code/wp-ops/scripts/release/release-theme.sh nynaeve 3.1.0` (`--commit` to auto-commit, `--ai=claude|codex|vibe` to pick the CLI). It resolves the theme under `site/` or `demo/`, so the same call works for `elayne`/`aviendha`.
+- If bumping by hand, verify parity before committing: `diff <(grep -o '^## \[[0-9.]*\]' CHANGELOG.md | tr -d '#[] ' | sort -V) <(grep -o '^= [0-9.]* ' readme.txt | tr -d '= ' | sort -V)`.
+- Real drift this prevents: `readme.txt`'s `Stable tag` sat at `2.15.8` through the whole 3.0.x line, and 2.15.9/2.15.10/3.0.0/3.0.1/3.0.2 were missing from its changelog — all bumped by hand without the script. In sync from 2.3.0 forward; pre-2.3.0 entries live only in `CHANGELOG.md` and are deliberately not back-filled.
+- Theme version ≠ block stylesheet version. Bumping the theme does not refresh a block's cached CSS — bump `block.json` `version` whenever a shipped block's `style.css`/`editor.css` changes (Trellis serves static assets with a one-year cache).
+
 ## Security & Configuration Tips
 - Never commit `.env`, vault files, or generated credentials; use `.env.example`.
 - Work from Trellis VM for any `wp`/`wp acorn` tasks (DB lives there; host MySQL on 3306 conflicts). Theme path in VM: `/srv/www/imagewize.com/current/web/app/themes/nynaeve`; demo: `/srv/www/demo.imagewize.com/current`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the Nynaeve theme will be documented in this file.
 
+## [3.1.0] - 2026-08-17
+
+### Added - Two-column single-post layout with sticky sidebar CTA
+
+**resources/views/partials/content-single.blade.php:**
+- Single posts render as a two-column grid at `xl+`: content column at the standard `55rem` `contentSize`, slim `18rem` sticky CTA card beside it
+- Below `xl` the aside is dropped entirely and the post behaves exactly as before — a single full-width column matching every other page template
+- `comments_template()` moved back into the content column so it aligns with the now-offset body instead of centering independently
+
+**resources/views/partials/blog-sidebar-card.blade.php (new):**
+- Sticky "Work With Me" CTA — quote button plus four service links
+- Styled to match the in-content CTA groups already used across the blog (tertiary panel, primary left accent rule, Montserrat heading, rounded primary button) rather than introducing a second CTA language
+
+**resources/views/partials/cta-blog.blade.php (removed):**
+- The full-bleed end-of-post CTA introduced in the previous revision of this work is superseded by the sidebar card
+
+### Technical - Three cascade-layer conflicts with WordPress and app.css
+
+Tailwind utilities live in `@layer utilities`. **Unlayered** rules beat them regardless of specificity, which is what caused all three of these. Each is commented inline at the point it matters.
+
+- **The grid cannot live on the `.wp-block-post-content` element.** WP core's `block-library/style.css` declares `.wp-block-post-content { display: flow-root }` unlayered, so `xl:grid` silently lost and the aside stacked below the post. The grid is on a plain wrapper instead, with `.wp-block-post-content` as its first child
+- **The card's white button label rendered invisible** (blue on blue): `app.css`'s `:is(…, .wp-block-post-content) a:not(.wp-element-button)` was repainting it `primary`. Keeping the aside a *sibling* of `.wp-block-post-content` rather than a descendant takes it out of that selector's scope
+- **The card heading rendered at article-`h2` size** — `app.css` styles bare `h2` unlayered, hence the `!` variants on that one element
+
+**Sticky stop position:**
+- The aside's `xl:mb-20` is load-bearing, not decoration. A sticky box is constrained so its *margin* box stays inside the containing block, so the margin is what stops the card short of the grid row's bottom instead of letting it ride flush into the footer. Padding on the grid wrapper cannot do this — it sits outside the tracks and never extends the grid area
+
+**Behaviour change:** at `xl+`, `alignfull` / `alignwide` blocks inside post bodies now bleed to the `55rem` content column rather than the viewport, since that column is the layout container. Below `xl` they still go edge-to-edge. This is the normal consequence of a sidebar layout.
+
+**Not included:** the `sidebar-primary` widget still holds the `imagewize/related-articles` block. It is unreferenced by this template and by `index.blade.php`, but removing the widget is a production data change tracked separately.
+
 ## [3.0.2] - 2026-08-16
 
 ### Fixed - Review Profiles avatars broken by Vite asset hashing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,41 @@ git checkout -b fix/service-hero-mobile-padding
 
 `release-theme.sh` diffs the current branch against `main` to generate the changelog, so work committed straight to `main` produces an empty release changelog.
 
+### Version Bumps Touch Four Places (CRITICAL)
+
+A release is **not** one version string, it is four, and they must all move together:
+
+| file | what changes |
+|---|---|
+| `style.css` | `Version:` header — the value WordPress reads; the source of truth `release-theme.sh` diffs against |
+| `readme.txt` | `Stable tag:` header |
+| `readme.txt` | a new `= X.Y.Z - MM/DD/YY =` block at the **top** of `== Changelog ==`, concise WordPress.org style, one line per change prefixed `FEATURE:` / `FIXED:` / `SECURITY:` / `TECHNICAL:` / `DOCUMENTATION:` / `BREAKING:` |
+| `CHANGELOG.md` | a new `## [X.Y.Z] - YYYY-MM-DD` section at the **top**, detailed Keep-a-Changelog style, grouped under `### Added` / `### Fixed` / `### Technical` / `### BREAKING`, naming the files touched |
+
+Note the two changelogs use **different date formats** (`MM/DD/YY` vs `YYYY-MM-DD`) and different levels of detail. `readme.txt` is the reader-facing summary; `CHANGELOG.md` is the engineering record.
+
+**Prefer the script over doing this by hand** — it updates all four and generates both changelog formats from the branch diff:
+
+```bash
+# from the repo root, NOT the theme directory
+cd /Users/jasperfrumau/code/imagewize.com
+~/code/wp-ops/scripts/release/release-theme.sh nynaeve 3.1.0
+# add --commit to auto-commit the bump; --ai=claude|codex|vibe to pick the CLI
+```
+
+It resolves the theme under `site/` or `demo/` automatically, so the same invocation works for `elayne` and `aviendha`.
+
+**If you bump by hand, verify parity before committing:**
+
+```bash
+diff <(grep -o '^## \[[0-9.]*\]' CHANGELOG.md | tr -d '#[] ' | sort -V) \
+     <(grep -o '^= [0-9.]* '      readme.txt   | tr -d '= '     | sort -V)
+```
+
+This drift is not hypothetical: `readme.txt`'s `Stable tag` sat at `2.15.8` through the entire 3.0.x line, and its changelog was missing 2.15.9, 2.15.10, 3.0.0, 3.0.1 and 3.0.2 — all bumped by hand without the script. Everything from 2.3.0 forward is now in sync; entries before 2.3.0 exist only in `CHANGELOG.md` and are deliberately not back-filled.
+
+**Block stylesheet versions are separate.** Bumping the theme version does *not* refresh a block's cached CSS — see [Block Standards](#block-standards) for the `block.json` `version` rule.
+
 ### Atomic Commits (CRITICAL)
 
 Stage files individually or in small logical groups and commit each with its own specific message. **Never stage unrelated files together** — e.g. commit documentation separately from block code, and a dependency bump separately from the fix that motivated it.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasperfrumau
 Requires at least: 6.6
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 2.15.8
+Stable tag: 3.1.0
 License: MIT License
 License URI: https://opensource.org/licenses/MIT
 
@@ -12,6 +12,48 @@ License URI: https://opensource.org/licenses/MIT
 Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) with Laravel Blade templating, Tailwind CSS 4, Vite, and custom WordPress blocks. Powers the imagewize.com digital agency website with WooCommerce quote-based integration.
 
 == Changelog ==
+
+= 3.1.0 - 08/17/26 =
+* FEATURE: Two-column single-post layout - content column at the standard 55rem contentSize with a slim 18rem sticky CTA card beside it at xl and up. Below xl the aside is dropped and the post renders as a single full-width column as before.
+* FEATURE: New sticky sidebar CTA card partial, styled to match the in-content CTA groups already used across the blog rather than introducing a second CTA language. Replaces the full-bleed end-of-post CTA partial.
+* FIXED: The two-column grid never applied - WordPress core's block-library stylesheet declares `.wp-block-post-content { display: flow-root }` outside any cascade layer, which beats Tailwind's layered `xl:grid` regardless of specificity, so the sidebar stacked below the post. The grid now lives on a plain wrapper element.
+* FIXED: The sidebar card's white button label rendered invisible (blue on blue) - a content-area link rule in app.css repainted it. Keeping the aside a sibling of `.wp-block-post-content` rather than a descendant takes it out of that selector's scope.
+* FIXED: The sidebar card heading rendered at article-h2 size, since app.css styles bare `h2` outside any cascade layer.
+* FIXED: The sticky card rode flush into the footer at the bottom of the page. A bottom margin on the aside stops it short - a sticky box keeps its margin box inside the containing block, and grid-wrapper padding cannot do this because it never extends the grid area.
+* TECHNICAL: Comments moved back into the content column so they align with the now-offset body.
+* TECHNICAL: At xl and up, alignfull/alignwide blocks inside post bodies now bleed to the 55rem content column rather than the viewport, since that column is the layout container. Below xl they still go edge-to-edge.
+
+= 3.0.2 - 08/16/26 =
+* FIXED: The three `imagewize/review-profiles` avatar images rendered broken on the frontend - `editor.jsx` imported the `.webp` files directly, so Vite hashed them into a build-time URL that got baked into saved post content. Same class of bug fixed for icons in 2.15.3.
+* TECHNICAL: Registered a new `imagewize/review-photo` block bindings source mirroring `imagewize/theme-icon`, resolving the current Vite asset URL at render time so published content survives future rebuilds.
+* TECHNICAL: Moved the three profile images into `resources/images/reviews/`, already covered by the `assets: ['resources/images/**']` glob in vite.config.js, so no build config change was needed.
+* NOTE: This fixes the block definition for all future inserts. Already-published instances still carry the old hashed src in post_content and need a one-time content migration, tracked separately.
+
+= 3.0.1 - 08/15/26 =
+* DOCUMENTATION: README block count corrected from 27 to 35 - the eight blocks added in 3.0.0 shipped without a README entry.
+* DOCUMENTATION: Added a Service CTAs section documenting the seven `cta-*` service blocks, and Quick Summary under Content & Layout.
+* TECHNICAL: Documentation only; no PHP, block, markup, styling, or build output changes.
+
+= 3.0.0 - 08/15/26 =
+* BREAKING: All blocks consolidated under the `imagewize` namespace. `nynaeve/about`, `nynaeve/cta-block-blue` and `nynaeve/contact-section` are renamed to `imagewize/*`. A block's name determines both its comment delimiter and its generated wrapper class, and both are stored in post content, so this requires a content migration after deploying - see CHANGELOG.md for the exact wp search-replace commands. Do not blanket-replace the string `nynaeve/`; post content also contains `/app/themes/nynaeve/...` asset paths.
+* BREAKING: Block stylesheet versions bumped for `contact-section`, `cta-block-blue` and `case-studies` - the rename rewrites every selector, and Trellis serves static assets with a one-year cache, so an unbumped `?ver=` would keep returning visitors on pre-rename CSS.
+* FIXED: The about block's entire stylesheet had been dead since 2026-04-08 - it targeted `.wp-block-imagewize-about` while the block generated `.wp-block-nynaeve-about`. Now live again. Same for the app.css inner-container padding reset and the case-studies editor.css selectors.
+* FIXED: `imagewize-cta-block-blue-style` in app/filters.php now matches a real handle, so the stylesheet is deferred as originally intended. All 15 entries audited against the block registry.
+* FIXED: The cta-block-blue button hover control had stopped matching since the rename; parent-block check updated.
+* FIXED: 57 posts still carrying pre-April `imagewize/about` markup had been rendering as unregistered blocks. The rename restores them without any migration.
+* FEATURE: Seven CTA service blocks - `imagewize/cta-seo-service`, `cta-fse-block-theme`, `cta-performance-partnership`, `cta-sage-agency`, `cta-trellis-hosting`, `cta-woocommerce`, `cta-wordpress-development` - replacing the copy-paste HTML workflow for adding service CTAs to posts.
+* FEATURE: New `imagewize/quick-summary` block - the highlighted callout used at the top of long-form posts.
+* FIXED: Outline button text was invisible on hover in all seven CTA blocks - blue on blue. `.is-style-outline` sits on the wrapper div, not the anchor, so the old rule set color where the anchor's inline color overrode it.
+* FIXED: CTA blocks rendered at wideSize while the post body sits at contentSize, so they overhung the text they follow. Removed the `align` default; wide/full remain available per instance.
+
+= 2.15.10 - 08/11/26 =
+* DOCUMENTATION: Added Packagist badges (Total Downloads, Latest Stable Version, License) to README.md alongside the existing Composer installation documentation.
+
+= 2.15.9 - 08/10/26 =
+* SECURITY: Updated guzzlehttp/guzzle 7.15.1 to 7.15.3, resolving two Dependabot advisories - noncanonical host can bypass host-based checks (high), and noncanonical cookie domain keeps subdomain scope (medium).
+* SECURITY: Updated nanoid 3.3.16 to 3.3.18, resolving a high-severity advisory where custom generators could loop indefinitely when size is zero.
+* SECURITY: Updated fast-uri 3.1.4 to 3.1.5, resolving a high-severity host confusion advisory via backslash authority introducer.
+* TECHNICAL: All three are transitive dependencies whose existing semver ranges already permitted the patched versions, so updates were scoped narrowly rather than as a broad dependency bump. No PHP, block, markup, styling, or build output changes.
 
 = 2.15.8 - 07/25/26 =
 * DOCUMENTATION: Fixed four broken relative doc links in CLAUDE.md that pointed at a `docs/` folder not present in the theme.
@@ -255,7 +297,17 @@ Nynaeve is the Imagewize.com production theme built on Sage 11 (Roots.io stack) 
 * FIXED: Quote block and pullquote block styling added.
 
 = 2.3.4 - 03/04/26 =
-* ADDED: Mistral Vibe AI integration config and prompts.
+* ADDED: Mistral Vibe AI integration config and prompts - `.vibe/config.toml` and `.vibe/prompts/claude.md`.
+
+= 2.3.3 - 03/03/26 =
+* ADDED: Mistral Vibe AI integration - `.vibe/config.toml` and `.vibe/prompts/claude.md` with project-specific agent instructions.
+
+= 2.3.2 - 03/03/26 =
+* ADDED: Mistral Vibe AI integration - `.vibe/prompt.md` with project-specific agent instructions.
+
+= 2.3.1 - 03/01/26 =
+* FIXED: Search overlay close button moved outside `.search-overlay-inner` to sit directly inside `.search-overlay`, so it is visible and positioned above the inner content area.
+* FIXED: Search overlay close button `top` offset adjusted from -2.5rem to 3rem so it renders within the visible overlay area.
 
 = 2.3.0 - 03/01/26 =
 * ADDED: Search overlay functionality with close button.

--- a/resources/views/partials/blog-sidebar-card.blade.php
+++ b/resources/views/partials/blog-sidebar-card.blade.php
@@ -1,0 +1,57 @@
+{{--
+  Slim sticky sidebar CTA for single posts (xl+ only). Replaces the old
+  full-column "Related Articles" widget, which logs showed got essentially zero
+  clicks and was hidden below `lg` anyway (see PR #394).
+
+  Styled to match the in-content CTA groups used across the blog — `tertiary`
+  panel, `primary` left accent rule, Montserrat heading, `rounded-[8px]`
+  primary button — rather than inventing a second CTA language.
+--}}
+<div class="bg-tertiary border-l-4 border-primary rounded-r-[10px] px-6 py-7">
+  <p class="text-xs font-semibold uppercase tracking-wider text-primary font-open-sans">
+    {{ __('Work With Me', 'nynaeve') }}
+  </p>
+
+  {{-- app.css styles bare `h2` outside any cascade layer, so plain Tailwind
+       utilities lose to it regardless of specificity — hence the `!` variants. --}}
+  <h2 class="mt-3 !text-lg !font-bold !leading-snug !text-main !font-montserrat">
+    {{ __('Need a WordPress developer?', 'nynaeve') }}
+  </h2>
+
+  <p class="mt-3 text-sm leading-relaxed text-main-accent font-open-sans">
+    {{ __('I build and maintain fast WordPress & WooCommerce sites on Trellis, Bedrock and Sage. No page builders, no retainer required.', 'nynaeve') }}
+  </p>
+
+  <a
+    href="{{ home_url('/contact/') }}"
+    class="mt-5 inline-flex w-full items-center justify-center rounded-[8px] bg-primary px-4 py-2.5 text-sm font-semibold text-white no-underline transition-colors duration-200 hover:bg-primary-dark"
+  >
+    {{ __('Get a Quote', 'nynaeve') }}
+  </a>
+
+  <p class="mt-7 pt-5 border-t border-border-dark/50 text-xs font-semibold uppercase tracking-wider text-secondary font-open-sans">
+    {{ __('Services', 'nynaeve') }}
+  </p>
+
+  <ul class="mt-3 list-none space-y-2.5 pl-0">
+    @foreach ([
+      '/services/wordpress-development/' => __('WordPress Development', 'nynaeve'),
+      '/services/woocommerce/' => __('WooCommerce', 'nynaeve'),
+      '/services/speed-optimization/' => __('Speed Optimization', 'nynaeve'),
+      '/services/managed-wordpress-hosting/' => __('Managed Hosting', 'nynaeve'),
+    ] as $path => $label)
+      <li>
+        <a
+          href="{{ home_url($path) }}"
+          class="group flex items-center justify-between gap-3 text-sm text-main no-underline transition-colors duration-200 hover:text-primary"
+        >
+          {{ $label }}
+          <span
+            aria-hidden="true"
+            class="text-primary transition-transform duration-200 group-hover:translate-x-0.5"
+          >&rarr;</span>
+        </a>
+      </li>
+    @endforeach
+  </ul>
+</div>

--- a/resources/views/partials/content-single.blade.php
+++ b/resources/views/partials/content-single.blade.php
@@ -1,6 +1,21 @@
-<article @php(post_class('h-entry container max-w-5xl mt-20 px-5 lg:mx-auto'))>
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-    <div class="content lg:col-span-2">
+<article @php(post_class('h-entry mt-20'))>
+  {{--
+    Two-column article layout (xl+): content column stays at contentSize (55rem)
+    while a slim sticky CTA card sits beside it. Below xl the aside is dropped
+    entirely and the content behaves exactly like every other page on the site.
+
+    The grid lives on a PLAIN wrapper, never on the `.wp-block-post-content`
+    element itself: WP core's block-library stylesheet sets
+    `.wp-block-post-content { display: flow-root }` unlayered, which beats
+    Tailwind's `xl:grid` (in `@layer utilities`) no matter the specificity —
+    the column would silently collapse and the aside would stack underneath.
+
+    Keeping the aside a *sibling* of `.wp-block-post-content` also keeps it out
+    of the content-area link rule in app.css, which would otherwise repaint the
+    card's white button label `primary` blue-on-blue.
+  --}}
+  <div class="alignfull pb-16 xl:grid xl:grid-cols-[minmax(0,55rem)_18rem] xl:justify-center xl:gap-12 xl:items-start">
+    <div class="wp-block-post-content is-layout-constrained">
       <header>
         <h1 class="p-name mb-8 antialiased !text-black">
           {!! $title !!}
@@ -24,8 +39,16 @@
       @php(comments_template())
     </div>
 
-    <div class="sidebar hidden lg:grid lg:col-span-1">
-      @include('sections.sidebar')
-    </div>
+    {{-- `items-start` above shrinks this track to its content height, which is
+         what lets `sticky` resolve against the full grid-row height.
+
+         `mb-20` is load-bearing, not decoration: a sticky box is constrained so
+         its *margin* box stays inside the containing block, so the margin is
+         what stops the card short of the row bottom instead of letting it ride
+         flush into the footer. Padding on the grid wrapper can't do this — that
+         sits outside the tracks and never extends the grid area. --}}
+    <aside class="hidden xl:block xl:sticky xl:top-24 xl:mb-20" aria-label="{{ __('Work with me', 'nynaeve') }}">
+      @include('partials.blog-sidebar-card')
+    </aside>
   </div>
 </article>

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Nynaeve
 Theme URI: https://imagewize.com
 Description: Modern WordPress theme built on Sage 11 with reusable custom blocks using WordPress native tools and the Roots.io stack.
-Version: 3.0.2
+Version: 3.1.0
 Author: Jasper Frumau
 Author URI: https://magewize.com
 Text Domain: nynaeve


### PR DESCRIPTION
This release delivers a two-column sticky sidebar layout for single blog posts and formalizes the theme's release version bump procedure in project documentation. The layout work introduces a new reusable Blade partial (`resources/views/partials/blog-sidebar-card.blade.php`) consumed by `content-single.blade.php`, keeping the sidebar card markup isolated from the post content template. Version 3.1.0 is recorded across all four required locations — the `Version:` header in `style.css`, the `Stable tag:` and changelog block in `readme.txt`, and a new dated section in `CHANGELOG.md` — maintaining the parity that previously drifted across the 3.0.x line. Documentation updates in `CLAUDE.md` and `AGENTS.md` capture the four-file version bump requirement so future releases follow the same procedure rather than being bumped by hand. The change is additive, spanning 7 files with 214 insertions and 9 deletions, with no breaking changes to existing block or template behavior.

**Single Post Layout:**
- Added `resources/views/partials/blog-sidebar-card.blade.php`, a dedicated partial for the blog sidebar card, so the sidebar markup can be maintained and reused independently of the single-post template.
- Updated `resources/views/partials/content-single.blade.php` to render a two-column layout with a sticky sidebar, improving navigation and secondary content visibility on long-form posts.

**Release Versioning:**
- Bumped the theme to 3.1.0 in `style.css` (`Version:`) and `readme.txt` (`Stable tag:`), keeping the WordPress-facing version headers in sync.
- Added matching changelog entries in both `readme.txt` (WordPress.org `= X.Y.Z - MM/DD/YY =` format) and `CHANGELOG.md` (Keep-a-Changelog `## [X.Y.Z] - YYYY-MM-DD` format), preserving the distinct date formats and detail levels each file requires.

**Documentation and Developer Guidance:**
- Documented the theme release version bump procedure in `CLAUDE.md` and `AGENTS.md`, enumerating the four files that must move together on every release and the verification command for detecting changelog drift.
- Recorded the historical drift context (the `Stable tag` stalling at 2.15.8 through the 3.0.x line) to explain why the release script is preferred over manual bumps.

**Files Changed:**

- [`AGENTS.md`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/AGENTS.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/CLAUDE.md) (Modified)
- [`readme.txt`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/readme.txt) (Modified)
- [`resources/views/partials/content-single.blade.php`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/resources/views/partials/content-single.blade.php) (Modified)
- [`style.css`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/style.css) (Modified)
- [`resources/views/partials/blog-sidebar-card.blade.php`](https://github.com/imagewize/nynaeve/blob/release/3.1.0/resources/views/partials/blog-sidebar-card.blade.php) (Added)